### PR TITLE
Create .gitignore file manually when bootstrapping a new package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "engines": {
     "node": ">=12",
-    "npm": ">=7.24.0"
+    "npm": ">=8.1.0"
   },
   "scripts": {
     "changelog": "node scripts/release/changelog.js",

--- a/packages/ckeditor5-package-generator/lib/index.js
+++ b/packages/ckeditor5-package-generator/lib/index.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+const { EOL } = require( 'os' );
 const path = require( 'path' );
 const fs = require( 'fs' );
 const { execSync, spawnSync } = require( 'child_process' );
@@ -29,6 +30,16 @@ const TEMPLATES_TO_FILL = [
 	'package.json',
 	'LICENSE.md',
 	'README.md'
+];
+
+// Npm does not publish the `.gitignore` file even if it's somewhere inside the package.
+// Hence, the package generator will create it manually. See: #50.
+const GITIGNORE_ENTRIES = [
+	'build/',
+	'coverage/',
+	'node_modules/',
+	'tmp/',
+	'sample/ckeditor.dist.js'
 ];
 
 new Command( packageJson.name )
@@ -137,6 +148,9 @@ async function init( packageName, options ) {
 
 		copyTemplate( templatePath, directoryPath, data );
 	}
+
+	// Create the `.gitignore` file. See #50.
+	fs.writeFileSync( path.join( directoryPath, '.gitignore' ), GITIGNORE_ENTRIES.join( EOL ) );
 
 	// (4.)
 	console.log( '📍 Installing dependencies...' );

--- a/packages/ckeditor5-package-generator/lib/index.js
+++ b/packages/ckeditor5-package-generator/lib/index.js
@@ -40,7 +40,8 @@ const GITIGNORE_ENTRIES = [
 	'coverage/',
 	'node_modules/',
 	'tmp/',
-	'sample/ckeditor.dist.js'
+	'sample/ckeditor.dist.js',
+	''
 ];
 
 new Command( packageJson.name )

--- a/packages/ckeditor5-package-generator/lib/templates/.gitignore
+++ b/packages/ckeditor5-package-generator/lib/templates/.gitignore
@@ -1,5 +1,0 @@
-build/
-coverage/
-node_modules/
-sample/script.dist.js
-tmp/


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (generator): Create `.gitignore` file manually when bootstrapping a new package. Closes #50.

Internal: Due to different results when publishing packages using npm, use the latest version to publish all files.
