### PR TITLE
Fixed lint scripts for Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "changelog": "node scripts/release/changelog.js",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test",
-    "lint": "eslint --quiet '**/*.js'",
+    "lint": "eslint --quiet \"**/*.js\"",
     "precommit": "lint-staged",
     "release:bump-version": "node scripts/release/bump-versions.js",
     "release:publish": "node scripts/release/publish.js",

--- a/packages/ckeditor5-package-generator/lib/templates/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/package.json
@@ -55,7 +55,7 @@
   "scripts": {
     "dll:build": "ckeditor5-package-tools dll:build",
     "dll:serve": "http-server ./ -o sample/dll.html",
-    "lint": "eslint '**/*.js' --quiet --ignore-pattern 'build/'",
+    "lint": "eslint \"**/*.js\" --quiet --ignore-pattern \"build/\"",
     "start": "ckeditor5-package-tools start",
     "stylelint": "stylelint --quiet --allow-empty-input 'theme/**/*.css'",
     "test": "ckeditor5-package-tools test",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (generator): Changed how arguments are specified for the `lint` task due to errors on Windows environments. Closes #65.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
