### PR TITLE
Changed handling of empty package name

### DIFF
--- a/packages/ckeditor5-package-generator/lib/index.js
+++ b/packages/ckeditor5-package-generator/lib/index.js
@@ -61,10 +61,10 @@ new Command( packageJson.name )
 	.parse( process.argv );
 
 /**
- * @param {String} packageName
+ * @param {String|undefined} packageName
  * @param {CKeditor5PackageGeneratorOptions} options
  */
-async function init( packageName = '', options ) {
+async function init( packageName, options ) {
 	// 1. Validate the package name.
 	// 2. Create a directory.
 	// 3. Collecting the latest version of CKEditor 5 dependencies.
@@ -93,7 +93,7 @@ async function init( packageName = '', options ) {
 		console.log( chalk.red( validationError ) + '\n' );
 
 		console.log( 'Expected pattern:            ' + chalk.green( '@[scope]/ckeditor5-[feature-name]' ) );
-		console.log( 'The provided package name:   ' + chalk.red( packageName ) );
+		console.log( 'The provided package name:   ' + chalk.red( packageName || '' ) );
 		console.log( 'Allowed characters list:     ' + chalk.blue( '0-9 a-z - . _' ) );
 
 		process.exit( 1 );

--- a/packages/ckeditor5-package-generator/lib/utils/validate-package-name.js
+++ b/packages/ckeditor5-package-generator/lib/utils/validate-package-name.js
@@ -12,11 +12,11 @@ const SCOPED_PACKAGE_REGEXP = /^@([^/]+)\/ckeditor5-([^/]+)$/;
  *
  * Returns a string containing the validation error, or `null` if no errors were found.
  *
- * @param {String} packageName
+ * @param {String|undefined} packageName
  * @returns {String|null}
  */
 module.exports = function validatePackageName( packageName ) {
-	if ( !packageName.length ) {
+	if ( !packageName ) {
 		return 'The package name cannot be an empty string - pass the name as the first argument to the script.';
 	}
 

--- a/packages/ckeditor5-package-generator/tests/utils/validate-package-name.js
+++ b/packages/ckeditor5-package-generator/tests/utils/validate-package-name.js
@@ -24,6 +24,12 @@ describe( 'lib/utils/validate-package-name', () => {
 	} );
 
 	describe( 'verifying package name length', () => {
+		it( 'rejects undefined value', () => {
+			const error = validatePackageName( undefined );
+
+			expect( error ).to.equal( 'The package name cannot be an empty string - pass the name as the first argument to the script.' );
+		} );
+
 		it( 'rejects an empty package name', () => {
 			const error = validatePackageName( '' );
 


### PR DESCRIPTION
Other (generator): Improved an error when no package name was specified during the command execution. Closes #72.