### PR TITLE
Integration with `Coveralls.io` service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,8 @@ install:
   - yarn install
 script:
   - yarn run test
+  - yarn run coverage
   - node scripts/ci/travis-check.js
+after_success:
+  - yarn add coveralls --ignore-workspace-root-check
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
 install:
   - yarn install
 script:
-  - yarn run test
   - yarn run coverage
   - node scripts/ci/travis-check.js
 after_success:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ CKEditor 5 Package Generator
 ========================
 
 [![Build Status](https://app.travis-ci.com/ckeditor/ckeditor5-package-generator.svg?branch=master)](https://app.travis-ci.com/ckeditor/ckeditor5-package-generator)
+[![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5-package-generator/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5-package-generator?branch=master)
 
 This repository follows the mono-repository structure. It contains multiple npm packages.
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "changelog": "node scripts/release/changelog.js",
-    "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test",
+    "coverage": "nyc --check-coverage --branches=100 --functions=100 --lines=100 --statements=100 --reporter=lcov --reporter=text-summary npm run test",
     "lint": "eslint --quiet \"**/*.js\"",
     "precommit": "lint-staged",
     "release:bump-version": "node scripts/release/bump-versions.js",

--- a/packages/ckeditor5-package-tools/lib/utils/get-karma-config.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-karma-config.js
@@ -45,7 +45,7 @@ module.exports = options => {
 		logLevel: 'INFO',
 
 		browsers: [
-			process.env.CI ? 'CHROME_TRAVIS_CI' : 'CHROME_LOCAL'
+			process.env.CI === 'true' ? 'CHROME_TRAVIS_CI' : 'CHROME_LOCAL'
 		],
 
 		customLaunchers: {

--- a/packages/ckeditor5-package-tools/tests/utils/get-karma-config.js
+++ b/packages/ckeditor5-package-tools/tests/utils/get-karma-config.js
@@ -60,6 +60,17 @@ describe( 'lib/utils/get-karma-config', () => {
 		expect( config.frameworks ).to.contain( 'webpack' );
 	} );
 
+	it( 'uses sandboxed version of Chrome when executing on local environment', () => {
+		const envCI = process.env.CI;
+		process.env.CI = false;
+
+		const config = getKarmaConfig( { cwd } );
+
+		expect( config.browsers ).to.deep.equal( [ 'CHROME_LOCAL' ] );
+
+		process.env.CI = envCI;
+	} );
+
 	it( 'uses no sandbox version of Chrome when executing on CI', () => {
 		const envCI = process.env.CI;
 		process.env.CI = true;

--- a/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-server.js
+++ b/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-server.js
@@ -105,6 +105,18 @@ describe( 'lib/utils/get-webpack-config-server', () => {
 		} );
 	} );
 
+	it( 'defines the development mode by default for an HTTP server', () => {
+		const config = getWebpackConfigServer( { cwd } );
+
+		expect( config.mode ).to.equal( 'development' );
+	} );
+
+	it( 'defines the production mode for an HTTP server', () => {
+		const config = getWebpackConfigServer( { cwd, production: true } );
+
+		expect( config.mode ).to.equal( 'production' );
+	} );
+
 	describe( 'sample language', () => {
 		it( 'passes the specified language directly to source file', () => {
 			getWebpackConfigServer( { cwd, language: 'en' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added integration with `Coveralls.io` service. Closes #81.

---

### Additional information

I've added a few tests, because on CI the coverage was below 100%.
