### PR TITLE
Added webpack to dependencies.

### DIFF
--- a/packages/ckeditor5-package-generator/package.json
+++ b/packages/ckeditor5-package-generator/package.json
@@ -15,7 +15,8 @@
     "commander": "^8.1.0",
     "glob": "^7.1.7",
     "lodash.template": "^4.5.0",
-    "mkdirp": "^1.0.4"
+    "mkdirp": "^1.0.4",
+    "webpack": "^5.67.0"
   },
   "files": [
     "lib"


### PR DESCRIPTION
Fix (generator): Added the missing `webpack` dependency to the `package.json` file. It fixes the _Cannot find module 'webpack'_ error. The `@ckeditor/ckeditor5-dev-utils` dependency defines peer dependencies, which must be installed manually in the generator package. Closes #89.