### PR TITLE
Allowed the "license-header" ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,12 @@ module.exports = {
 		node: true
 	},
 	rules: {
-		'no-console': 'off'
+		'no-console': 'off',
+		'ckeditor5-rules/license-header': [ 'error', { headerLines: [
+			'/**',
+			' * @license Copyright (c) 2020-2022, CKSource Holding sp. z o.o. All rights reserved.',
+			' * For licensing, see LICENSE.md.',
+			' */'
+		] } ]
 	}
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@ckeditor/ckeditor5-dev-env": "^27.4.0",
     "chalk": "^4.1.2",
     "eslint": "^7.32.0",
-    "eslint-config-ckeditor5": "^3.1.0",
+    "eslint-config-ckeditor5": "^4.0.0",
     "husky": "^4.3.8",
     "lint-staged": "^10.5.4",
     "mocha": "^9.1.1",


### PR DESCRIPTION
Internal: Allowed the "license-header" ESLint rule. See ckeditor/ckeditor5#11468.