### PR TITLE
Aligned the translations tools to the new API

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "license": "MIT",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-docs": "^27.4.0",
-    "@ckeditor/ckeditor5-dev-env": "^27.4.0",
+    "@ckeditor/ckeditor5-dev-docs": "^29.0.0",
+    "@ckeditor/ckeditor5-dev-env": "^29.0.0",
     "chalk": "^4.1.2",
     "eslint": "^7.32.0",
     "eslint-config-ckeditor5": "^3.1.0",

--- a/packages/ckeditor5-package-generator/package.json
+++ b/packages/ckeditor5-package-generator/package.json
@@ -10,7 +10,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^27.3.0",
+    "@ckeditor/ckeditor5-dev-utils": "^29.0.0",
     "chalk": "^4.1.2",
     "commander": "^8.1.0",
     "glob": "^7.1.7",

--- a/packages/ckeditor5-package-tools/lib/tasks/translations-download.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/translations-download.js
@@ -8,8 +8,16 @@
 const path = require( 'path' );
 
 module.exports = async options => {
-	if ( !options.transifex ) {
-		throw new Error( 'The URL to the Transifex API is required. Use --transifex [API end-point] to provide the value.' );
+	if ( !options.organization ) {
+		throw new Error( 'The URL to the Transifex API is required. Use --organization [organization name] to provide the value.' );
+	}
+
+	if ( !options.project ) {
+		throw new Error( 'The URL to the Transifex API is required. Use --project [project name] to provide the value.' );
+	}
+
+	if ( options.transifex ) {
+		throw new Error( 'The -- transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.' );
 	}
 
 	const getToken = require( '@ckeditor/ckeditor5-dev-env/lib/translations/gettoken' );
@@ -26,8 +34,9 @@ module.exports = async options => {
 			[ packageName, '.' ]
 		] ),
 
-		// End-point API URL to the Transifex service.
-		url: options.transifex,
+		// Transifex project details.
+		organizationName: options.organization,
+		projectName: options.project,
 
 		// An absolute path to the package.
 		cwd: options.cwd,

--- a/packages/ckeditor5-package-tools/lib/tasks/translations-download.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/translations-download.js
@@ -9,15 +9,15 @@ const path = require( 'path' );
 
 module.exports = async options => {
 	if ( !options.organization ) {
-		throw new Error( 'The URL to the Transifex API is required. Use --organization [organization name] to provide the value.' );
+		throw new Error( 'The organization name is required. Use --organization [organization name] to provide the value.' );
 	}
 
 	if ( !options.project ) {
-		throw new Error( 'The URL to the Transifex API is required. Use --project [project name] to provide the value.' );
+		throw new Error( 'The project name is required. Use --project [project name] to provide the value.' );
 	}
 
 	if ( options.transifex ) {
-		throw new Error( 'The -- transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.' );
+		throw new Error( 'The --transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.' );
 	}
 
 	const getToken = require( '@ckeditor/ckeditor5-dev-env/lib/translations/gettoken' );

--- a/packages/ckeditor5-package-tools/lib/tasks/translations-upload.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/translations-upload.js
@@ -8,8 +8,16 @@
 const path = require( 'path' );
 
 module.exports = async options => {
-	if ( !options.transifex ) {
-		throw new Error( 'The URL to the Transifex API is required. Use --transifex [API end-point] to provide the value.' );
+	if ( !options.organization ) {
+		throw new Error( 'The URL to the Transifex API is required. Use --organization [organization name] to provide the value.' );
+	}
+
+	if ( !options.project ) {
+		throw new Error( 'The URL to the Transifex API is required. Use --project [project name] to provide the value.' );
+	}
+
+	if ( options.transifex ) {
+		throw new Error( 'The -- transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.' );
 	}
 
 	const getToken = require( '@ckeditor/ckeditor5-dev-env/lib/translations/gettoken' );
@@ -18,8 +26,9 @@ module.exports = async options => {
 		// Token used for authentication with the Transifex service.
 		token: await getToken(),
 
-		// End-point API URL to the Transifex service.
-		url: options.transifex,
+		// Transifex project details.
+		organizationName: options.organization,
+		projectName: options.project,
 
 		// Where to look for the saved translation files.
 		translationsDirectory: path.join( options.cwd, 'tmp', '.transifex' )

--- a/packages/ckeditor5-package-tools/lib/tasks/translations-upload.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/translations-upload.js
@@ -9,15 +9,15 @@ const path = require( 'path' );
 
 module.exports = async options => {
 	if ( !options.organization ) {
-		throw new Error( 'The URL to the Transifex API is required. Use --organization [organization name] to provide the value.' );
+		throw new Error( 'The organization name is required. Use --organization [organization name] to provide the value.' );
 	}
 
 	if ( !options.project ) {
-		throw new Error( 'The URL to the Transifex API is required. Use --project [project name] to provide the value.' );
+		throw new Error( 'The project name is required. Use --project [project name] to provide the value.' );
 	}
 
 	if ( options.transifex ) {
-		throw new Error( 'The -- transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.' );
+		throw new Error( 'The --transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.' );
 	}
 
 	const getToken = require( '@ckeditor/ckeditor5-dev-env/lib/translations/gettoken' );

--- a/packages/ckeditor5-package-tools/lib/tasks/translations-upload.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/translations-upload.js
@@ -22,6 +22,9 @@ module.exports = async options => {
 
 	const getToken = require( '@ckeditor/ckeditor5-dev-env/lib/translations/gettoken' );
 
+	const pkgJson = require( path.join( options.cwd, 'package.json' ) );
+	const packageName = pkgJson.name.split( '/' ).pop();
+
 	return require( '@ckeditor/ckeditor5-dev-env' ).uploadPotFiles( {
 		// Token used for authentication with the Transifex service.
 		token: await getToken(),
@@ -30,7 +33,12 @@ module.exports = async options => {
 		organizationName: options.organization,
 		projectName: options.project,
 
-		// Where to look for the saved translation files.
-		translationsDirectory: path.join( options.cwd, 'tmp', '.transifex' )
+		// List of packages that will be processed.
+		packages: new Map( [
+			[ packageName, path.join( 'tmp', '.transifex', packageName ) ]
+		] ),
+
+		// An absolute path to the package.
+		cwd: options.cwd
 	} );
 };

--- a/packages/ckeditor5-package-tools/lib/utils/parse-arguments.js
+++ b/packages/ckeditor5-package-tools/lib/utils/parse-arguments.js
@@ -9,6 +9,11 @@ const minimist = require( 'minimist' );
 
 module.exports = args => {
 	const config = {
+		string: [
+			'organization',
+			'project'
+		],
+
 		boolean: [
 			'coverage',
 			'open',
@@ -30,10 +35,11 @@ module.exports = args => {
 			open: true,
 			language: 'en',
 			verbose: false,
+			organization: null,
 			production: false,
+			project: null,
 			watch: false,
-			'source-map': false,
-			transifex: null
+			'source-map': false
 		}
 	};
 

--- a/packages/ckeditor5-package-tools/package.json
+++ b/packages/ckeditor5-package-tools/package.json
@@ -11,9 +11,9 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^27.3.0",
-    "@ckeditor/ckeditor5-dev-env": "^27.3.0",
-    "@ckeditor/ckeditor5-dev-webpack-plugin": "^27.3.0",
+    "@ckeditor/ckeditor5-dev-utils": "^29.0.0",
+    "@ckeditor/ckeditor5-dev-env": "^29.0.0",
+    "@ckeditor/ckeditor5-dev-webpack-plugin": "^29.0.0",
     "buffer": "^6.0.3",
     "chai": "^4.3.4",
     "css-loader": "^5.2.7",

--- a/packages/ckeditor5-package-tools/tests/tasks/translations-download.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/translations-download.js
@@ -81,7 +81,7 @@ describe( 'lib/tasks/translations-download', () => {
 			} );
 		} catch ( err ) {
 			expect( err.message ).to.equal(
-				'The URL to the Transifex API is required. Use --organization [organization name] to provide the value.'
+				'The organization name is required. Use --organization [organization name] to provide the value.'
 			);
 		}
 	} );
@@ -94,7 +94,7 @@ describe( 'lib/tasks/translations-download', () => {
 			} );
 		} catch ( err ) {
 			expect( err.message ).to.equal(
-				'The URL to the Transifex API is required. Use --project [project name] to provide the value.'
+				'The project name is required. Use --project [project name] to provide the value.'
 			);
 		}
 	} );
@@ -109,7 +109,7 @@ describe( 'lib/tasks/translations-download', () => {
 			} );
 		} catch ( err ) {
 			expect( err.message ).to.equal(
-				'The -- transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.'
+				'The --transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.'
 			);
 		}
 	} );

--- a/packages/ckeditor5-package-tools/tests/tasks/translations-download.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/translations-download.js
@@ -55,7 +55,8 @@ describe( 'lib/tasks/translations-download', () => {
 
 		const results = await translationsDownload( {
 			cwd: '/workspace',
-			transifex: 'https://api.example.com'
+			organization: 'foo',
+			project: 'bar'
 		} );
 
 		expect( results ).to.equal( 'OK' );
@@ -63,7 +64,8 @@ describe( 'lib/tasks/translations-download', () => {
 		expect( stubs.devEnv.downloadTranslations.calledOnce ).to.equal( true );
 		expect( stubs.devEnv.downloadTranslations.firstCall.firstArg ).to.deep.equal( {
 			token: 'secretToken',
-			url: 'https://api.example.com',
+			organizationName: 'foo',
+			projectName: 'bar',
 			cwd: '/workspace',
 			packages: new Map( [
 				[ 'ckeditor5-foo', '.' ]
@@ -72,14 +74,42 @@ describe( 'lib/tasks/translations-download', () => {
 		} );
 	} );
 
-	it( 'throws an error if the "transifex" option is not specified', async () => {
+	it( 'throws an error if the "organization" option is not specified', async () => {
 		try {
 			await translationsDownload( {
 				cwd: '/workspace'
 			} );
 		} catch ( err ) {
 			expect( err.message ).to.equal(
-				'The URL to the Transifex API is required. Use --transifex [API end-point] to provide the value.'
+				'The URL to the Transifex API is required. Use --organization [organization name] to provide the value.'
+			);
+		}
+	} );
+
+	it( 'throws an error if the "project" option is not specified', async () => {
+		try {
+			await translationsDownload( {
+				cwd: '/workspace',
+				organization: 'foo'
+			} );
+		} catch ( err ) {
+			expect( err.message ).to.equal(
+				'The URL to the Transifex API is required. Use --project [project name] to provide the value.'
+			);
+		}
+	} );
+
+	it( 'throws an error if the "transifex" option is specified', async () => {
+		try {
+			await translationsDownload( {
+				cwd: '/workspace',
+				organization: 'foo',
+				project: 'bar',
+				transifex: 'https://api.example.com'
+			} );
+		} catch ( err ) {
+			expect( err.message ).to.equal(
+				'The -- transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.'
 			);
 		}
 	} );

--- a/packages/ckeditor5-package-tools/tests/tasks/translations-upload.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/translations-upload.js
@@ -80,7 +80,7 @@ describe( 'lib/tasks/translations-upload', () => {
 			} );
 		} catch ( err ) {
 			expect( err.message ).to.equal(
-				'The URL to the Transifex API is required. Use --organization [organization name] to provide the value.'
+				'The organization name is required. Use --organization [organization name] to provide the value.'
 			);
 		}
 	} );
@@ -93,7 +93,7 @@ describe( 'lib/tasks/translations-upload', () => {
 			} );
 		} catch ( err ) {
 			expect( err.message ).to.equal(
-				'The URL to the Transifex API is required. Use --project [project name] to provide the value.'
+				'The project name is required. Use --project [project name] to provide the value.'
 			);
 		}
 	} );
@@ -108,7 +108,7 @@ describe( 'lib/tasks/translations-upload', () => {
 			} );
 		} catch ( err ) {
 			expect( err.message ).to.equal(
-				'The -- transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.'
+				'The --transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.'
 			);
 		}
 	} );

--- a/packages/ckeditor5-package-tools/tests/tasks/translations-upload.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/translations-upload.js
@@ -52,7 +52,8 @@ describe( 'lib/tasks/translations-upload', () => {
 
 		const results = await translationsUpload( {
 			cwd: '/workspace',
-			transifex: 'https://api.example.com'
+			organization: 'foo',
+			project: 'bar'
 		} );
 
 		expect( results ).to.equal( 'OK' );
@@ -61,18 +62,47 @@ describe( 'lib/tasks/translations-upload', () => {
 		expect( stubs.devEnv.uploadPotFiles.firstCall.firstArg ).to.deep.equal( {
 			token: 'secretToken',
 			translationsDirectory: '/workspace/tmp/.transifex',
-			url: 'https://api.example.com'
+			organizationName: 'foo',
+			projectName: 'bar'
 		} );
 	} );
 
-	it( 'throws an error if the "transifex" option is not specified', async () => {
+	it( 'throws an error if the "organization" option is not specified', async () => {
 		try {
 			await translationsUpload( {
 				cwd: '/workspace'
 			} );
 		} catch ( err ) {
 			expect( err.message ).to.equal(
-				'The URL to the Transifex API is required. Use --transifex [API end-point] to provide the value.'
+				'The URL to the Transifex API is required. Use --organization [organization name] to provide the value.'
+			);
+		}
+	} );
+
+	it( 'throws an error if the "project" option is not specified', async () => {
+		try {
+			await translationsUpload( {
+				cwd: '/workspace',
+				organization: 'foo'
+			} );
+		} catch ( err ) {
+			expect( err.message ).to.equal(
+				'The URL to the Transifex API is required. Use --project [project name] to provide the value.'
+			);
+		}
+	} );
+
+	it( 'throws an error if the "transifex" option is specified', async () => {
+		try {
+			await translationsUpload( {
+				cwd: '/workspace',
+				organization: 'foo',
+				project: 'bar',
+				transifex: 'https://api.example.com'
+			} );
+		} catch ( err ) {
+			expect( err.message ).to.equal(
+				'The -- transifex [API end-point] option is no longer supported. Use `--organization` and `--project` instead.'
 			);
 		}
 	} );

--- a/packages/ckeditor5-package-tools/tests/tasks/translations-upload.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/translations-upload.js
@@ -31,6 +31,9 @@ describe( 'lib/tasks/translations-upload', () => {
 
 		mockery.registerMock( 'path', stubs.path );
 		mockery.registerMock( 'glob', stubs.glob );
+		mockery.registerMock( '/workspace/package.json', {
+			name: '@ckeditor/ckeditor5-foo'
+		} );
 		mockery.registerMock( '@ckeditor/ckeditor5-dev-env', stubs.devEnv );
 		mockery.registerMock( '@ckeditor/ckeditor5-dev-env/lib/translations/gettoken', stubs.getToken );
 
@@ -61,8 +64,11 @@ describe( 'lib/tasks/translations-upload', () => {
 		expect( stubs.devEnv.uploadPotFiles.calledOnce ).to.equal( true );
 		expect( stubs.devEnv.uploadPotFiles.firstCall.firstArg ).to.deep.equal( {
 			token: 'secretToken',
-			translationsDirectory: '/workspace/tmp/.transifex',
+			cwd: '/workspace',
 			organizationName: 'foo',
+			packages: new Map( [
+				[ 'ckeditor5-foo', 'tmp/.transifex/ckeditor5-foo' ]
+			] ),
 			projectName: 'bar'
 		} );
 	} );

--- a/packages/ckeditor5-package-tools/tests/utils/parse-arguments.js
+++ b/packages/ckeditor5-package-tools/tests/utils/parse-arguments.js
@@ -34,6 +34,9 @@ describe( 'lib/utils/parse-arguments', () => {
 		expect( options.watch ).to.equal( false );
 		expect( options.open ).to.equal( true );
 		expect( options.language ).to.equal( 'en' );
+		expect( options.organization ).to.equal( null );
+		expect( options.project ).to.equal( null );
+		expect( options.transifex ).to.equal( undefined );
 	} );
 
 	it( 'assigns the current work directory as the "#cwd" property', () => {
@@ -130,5 +133,17 @@ describe( 'lib/utils/parse-arguments', () => {
 		const options = parseArguments( [ 'task-to-execute', '--language', 'pl' ] );
 
 		expect( options.language ).to.equal( 'pl' );
+	} );
+
+	it( 'allows specifying the organization option', () => {
+		const options = parseArguments( [ 'task-to-execute', '--organization', 'bar' ] );
+
+		expect( options.organization ).to.equal( 'bar' );
+	} );
+
+	it( 'allows specifying the project option', () => {
+		const options = parseArguments( [ 'task-to-execute', '--project', 'foo' ] );
+
+		expect( options.project ).to.equal( 'foo' );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (tools): Aligned the translations tools to the new API exported by the `@ckeditor/ckeditor5-dev-env` package. Closes #71.

MAJOR BREAKING CHANGES (tools): The `-- transifex [API end-point]` option is no longer supported. Use the following options: `--organization [organization name]` and `--project [project name]` instead.

---

### Additional information

* Requires: https://github.com/ckeditor/ckeditor5-dev/pull/761

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
