### PR TITLE
Upgraded the `postcss` version to 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "license": "MIT",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-docs": "^27.4.0",
-    "@ckeditor/ckeditor5-dev-env": "^27.4.0",
+    "@ckeditor/ckeditor5-dev-docs": "^30.0.0",
+    "@ckeditor/ckeditor5-dev-env": "^30.0.0",
     "chalk": "^4.1.2",
     "eslint": "^7.32.0",
     "eslint-config-ckeditor5": "^4.0.0",

--- a/packages/ckeditor5-package-generator/package.json
+++ b/packages/ckeditor5-package-generator/package.json
@@ -10,7 +10,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^27.3.0",
+    "@ckeditor/ckeditor5-dev-utils": "^30.0.0",
     "chalk": "^4.1.2",
     "commander": "^8.1.0",
     "glob": "^7.1.7",

--- a/packages/ckeditor5-package-tools/package.json
+++ b/packages/ckeditor5-package-tools/package.json
@@ -11,9 +11,9 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^27.3.0",
-    "@ckeditor/ckeditor5-dev-env": "^27.3.0",
-    "@ckeditor/ckeditor5-dev-webpack-plugin": "^27.3.0",
+    "@ckeditor/ckeditor5-dev-utils": "^30.0.0",
+    "@ckeditor/ckeditor5-dev-env": "^30.0.0",
+    "@ckeditor/ckeditor5-dev-webpack-plugin": "^30.0.0",
     "buffer": "^6.0.3",
     "chai": "^4.3.4",
     "css-loader": "^5.2.7",

--- a/packages/ckeditor5-package-tools/package.json
+++ b/packages/ckeditor5-package-tools/package.json
@@ -31,7 +31,7 @@
     "minimist": "^1.2.5",
     "mocha": "^7.2.0",
     "process": "^0.11.10",
-    "postcss": "^7.0.39",
+    "postcss": "^8.4.12",
     "postcss-loader": "^4.3.0",
     "raw-loader": "^4.0.2",
     "sinon": "^9.2.4",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Packages generated by the tool use PostCSS@8 now. See ckeditor/ckeditor5#11460.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
