### PR TITLE
Removed isToggleable property from the template

### DIFF
--- a/packages/ckeditor5-package-generator/lib/templates/src/myplugin.js
+++ b/packages/ckeditor5-package-generator/lib/templates/src/myplugin.js
@@ -20,8 +20,7 @@ export default class MyPlugin extends Plugin {
 			view.set( {
 				label: t( 'My plugin' ),
 				icon: ckeditor5Icon,
-				tooltip: true,
-				isToggleable: true
+				tooltip: true
 			} );
 
 			// Insert a text into the editor after clicking the button.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (generator): Removed the `isToggleable` property from the plugin template. Closes #97.

---

### Additional information

I checked tests (they pass) but I didn't generate a package with this change to ensure that it's working as expected.

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
