### PR TITLE
Get the latest inspector version from npm

### DIFF
--- a/packages/ckeditor5-package-generator/lib/templates/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/package.json
@@ -38,7 +38,7 @@
     "@ckeditor/ckeditor5-heading": ">=<%= packageVersions.ckeditor5 %>",
     "@ckeditor/ckeditor5-image": ">=<%= packageVersions.ckeditor5 %>",
     "@ckeditor/ckeditor5-indent": ">=<%= packageVersions.ckeditor5 %>",
-    "@ckeditor/ckeditor5-inspector": "^2.2.2",
+    "@ckeditor/ckeditor5-inspector": ">=<%= packageVersions.ckeditor5Inspector %>",
     "@ckeditor/ckeditor5-link": ">=<%= packageVersions.ckeditor5 %>",
     "@ckeditor/ckeditor5-list": ">=<%= packageVersions.ckeditor5 %>",
     "@ckeditor/ckeditor5-media-embed": ">=<%= packageVersions.ckeditor5 %>",

--- a/packages/ckeditor5-package-generator/lib/utils/get-dependencies-versions.js
+++ b/packages/ckeditor5-package-generator/lib/utils/get-dependencies-versions.js
@@ -12,6 +12,7 @@ const getPackageVersion = require( './get-package-version' );
  * Returns an object containing version for the packages listed below:
  *
  *   * ckeditor5
+ *   * @ckeditor/ckeditor5-inspector (as `ckeditor5Inspector`)
  *   * eslint-config-ckeditor5 (as `eslintConfigCkeditor5`)
  *   * stylelint-config-ckeditor5 (as `stylelintConfigCkeditor5`)
  *   * @ckeditor/ckeditor5-package-tools (as `packageTools`)
@@ -28,6 +29,7 @@ const getPackageVersion = require( './get-package-version' );
 module.exports = function getDependenciesVersions( { devMode } ) {
 	return {
 		ckeditor5: getPackageVersion( 'ckeditor5' ),
+		ckeditor5Inspector: getPackageVersion( '@ckeditor/ckeditor5-inspector' ),
 		eslintConfigCkeditor5: getPackageVersion( 'eslint-config-ckeditor5' ),
 		stylelintConfigCkeditor5: getPackageVersion( 'stylelint-config-ckeditor5' ),
 		packageTools: devMode ?

--- a/packages/ckeditor5-package-generator/tests/utils/get-dependencies-versions.js
+++ b/packages/ckeditor5-package-generator/tests/utils/get-dependencies-versions.js
@@ -25,6 +25,7 @@ describe( 'lib/utils/get-dependencies-versions', () => {
 		mockery.registerMock( './get-package-version', getPackageVersion );
 		getPackageVersion.withArgs( 'ckeditor5' ).returns( '30.0.0' );
 		getPackageVersion.withArgs( '@ckeditor/ckeditor5-package-tools' ).returns( '1.0.0' );
+		getPackageVersion.withArgs( '@ckeditor/ckeditor5-inspector' ).returns( '4.0.0' );
 		getPackageVersion.withArgs( 'eslint-config-ckeditor5' ).returns( '5.0.0' );
 		getPackageVersion.withArgs( 'stylelint-config-ckeditor5' ).returns( '3.0.0' );
 
@@ -53,6 +54,11 @@ describe( 'lib/utils/get-dependencies-versions', () => {
 	it( 'returns an object with a version of the "stylelint-config-ckeditor5" package', () => {
 		const returnedValue = getDependenciesVersions( { devMode: false } );
 		expect( returnedValue.stylelintConfigCkeditor5 ).to.equal( '3.0.0' );
+	} );
+
+	it( 'returns an object with a version of the "@ckeditor/ckeditor5-package-tools" package', () => {
+		const returnedValue = getDependenciesVersions( { devMode: false } );
+		expect( returnedValue.ckeditor5Inspector ).to.equal( '4.0.0' );
 	} );
 
 	it( 'returns an object with a version of the "@ckeditor/ckeditor5-package-tools" package if "devMode" is disabled', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (generator): When creating a new package, a version of the `@ckeditor/ckeditor5-inspector` package should be taken from the npm registry. Closes #96.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
