### PR TITLE
Added support for collecting translation entries from TypeScript files

### DIFF
--- a/packages/ckeditor5-package-tools/lib/tasks/translations-collect.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/translations-collect.js
@@ -10,7 +10,7 @@ const glob = require( 'glob' );
 
 module.exports = options => {
 	// Glob handles posix paths.
-	const sourceFilesGlob = path.join( options.cwd, 'src', '**', '*.js' ).split( /[\\/]/g ).join( '/' );
+	const sourceFilesGlob = path.join( options.cwd, 'src', '**', '*.[jt]s' ).split( /[\\/]/g ).join( '/' );
 
 	return require( '@ckeditor/ckeditor5-dev-env' ).createPotFiles( {
 		// An array containing absolute paths the package sources.

--- a/packages/ckeditor5-package-tools/tests/tasks/translations-collect.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/translations-collect.js
@@ -47,7 +47,7 @@ describe( 'lib/tasks/translations-collect', () => {
 		expect( translationsCollect ).to.be.a( 'function' );
 	} );
 
-	it( 'creates translation files', () => {
+	it( 'creates translation files (JavaScript)', () => {
 		const sourceFiles = [
 			'/workspace/ckeditor5-foo/src/index.js',
 			'/workspace/ckeditor5-foo/src/myplugin.js'
@@ -63,7 +63,44 @@ describe( 'lib/tasks/translations-collect', () => {
 		expect( results ).to.equal( 'OK' );
 
 		expect( stubs.glob.sync.calledOnce ).to.equal( true );
-		expect( stubs.glob.sync.firstCall.firstArg ).to.equal( '/workspace/src/**/*.js' );
+		expect( stubs.glob.sync.firstCall.firstArg ).to.equal( '/workspace/src/**/*.[jt]s' );
+
+		expect( stubs.devEnv.createPotFiles.calledOnce ).to.equal( true );
+		expect( stubs.devEnv.createPotFiles.firstCall.firstArg ).to.deep.equal( {
+			// Verify results returned by `glob.sync()`.
+			sourceFiles,
+			// Verify a path to the `@ckeditor/ckeditor5-core` package.
+			corePackagePath: 'node_modules/@ckeditor/ckeditor5-core',
+			// Verify ignoring unused contexts from the `@ckeditor/ckeditor5-core` package.
+			ignoreUnusedCorePackageContexts: true,
+			// Verify a path where to look for packages.
+			packagePaths: [
+				'/workspace'
+			],
+			// Verify the license header in translation files.
+			skipLicenseHeader: true,
+			// Verify a path where translations will be stored.
+			translationsDirectory: '/workspace/tmp/.transifex'
+		} );
+	} );
+
+	it( 'creates translation files (TypeScript)', () => {
+		const sourceFiles = [
+			'/workspace/ckeditor5-foo/src/index.ts',
+			'/workspace/ckeditor5-foo/src/myplugin.ts'
+		];
+
+		stubs.glob.sync.returns( sourceFiles );
+		stubs.devEnv.createPotFiles.returns( 'OK' );
+
+		const results = translationsCollect( {
+			cwd: '/workspace'
+		} );
+
+		expect( results ).to.equal( 'OK' );
+
+		expect( stubs.glob.sync.calledOnce ).to.equal( true );
+		expect( stubs.glob.sync.firstCall.firstArg ).to.equal( '/workspace/src/**/*.[jt]s' );
 
 		expect( stubs.devEnv.createPotFiles.calledOnce ).to.equal( true );
 		expect( stubs.devEnv.createPotFiles.firstCall.firstArg ).to.deep.equal( {
@@ -94,6 +131,6 @@ describe( 'lib/tasks/translations-collect', () => {
 		expect( results ).to.equal( 'OK' );
 
 		expect( stubs.glob.sync.calledOnce ).to.equal( true );
-		expect( stubs.glob.sync.firstCall.firstArg ).to.equal( 'C:/workspace/src/**/*.js' );
+		expect( stubs.glob.sync.firstCall.firstArg ).to.equal( 'C:/workspace/src/**/*.[jt]s' );
 	} );
 } );

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -21,9 +21,17 @@ const NEW_PACKAGE_DIRECTORY = path.join( REPOSITORY_DIRECTORY, '..', 'ckeditor5-
 // A flag that determines whether any of the executed commands resulted in an error.
 let foundError = false;
 
-testBuild( 'js' )
-	.then( () => testBuild( 'ts' ) )
-	.then( () => process.exit( foundError ? 1 : 0 ) );
+start();
+
+/**
+ * Runs checks and exits with an appropriate exit code.
+ */
+async function start() {
+	await testBuild( 'js' );
+	await testBuild( 'ts' );
+
+	process.exit( foundError ? 1 : 0 );
+}
 
 /**
  * Build and run scripts for a given language.
@@ -48,10 +56,8 @@ async function testBuild( lang ) {
 	executeCommand( NEW_PACKAGE_DIRECTORY, 'yarn', [ 'run', 'lint' ] );
 	executeCommand( NEW_PACKAGE_DIRECTORY, 'yarn', [ 'run', 'stylelint' ] );
 
-	if ( lang !== 'ts' ) {
-		logProcess( 'Verifying translations...' );
-		executeCommand( NEW_PACKAGE_DIRECTORY, 'yarn', [ 'run', 'translations:collect' ] );
-	}
+	logProcess( 'Verifying translations...' );
+	executeCommand( NEW_PACKAGE_DIRECTORY, 'yarn', [ 'run', 'translations:collect' ] );
 
 	logProcess( 'Starting the development servers and verifying the sample builds...' );
 	await Promise.all( [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added support for collecting translation entries from TypeScript files. Closes #106.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
