### PR TITLE
Added --use-yarn flag to package generator and set it to true by default when yarn is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ The tool will create a new directory called `ckeditor5-package` with an example 
 To use a local version of the `@ckeditor/ckeditor5-package-tools` package, use the `--dev` option when executing the command.
 
 ```bash
-node /path/to/repository/packages/ckeditor5-package-generator <packageName> [--dev] [--verbose] [--use-npm]
+node /path/to/repository/packages/ckeditor5-package-generator <packageName> [--dev] [--verbose] [--use-npm] [--use-yarn]
 ```
 
 #### Options
 
 * `--verbose` - (alias: `-v`) whether to prints additional logs about the current executed task.
 * `--dev` - whether to execute in the development mode. It means that the `@ckeditor/ckeditor5-package-tools` will not be installed from npm, but from the local file system.
-* `--use-npm` - whether to use `npm` instead of `yarn` when installing dependencies in a newly created package.
+* `--use-npm` - whether to use `npm` to install dependencies in a newly created package.
+* `--use-yarn` - whether to use `yarn` to install dependencies in a newly created package. If `yarn` is installed globally it is used by default.
 
 #### Developing the package
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ node /path/to/repository/packages/ckeditor5-package-generator <packageName> [--d
 * `--verbose` - (alias: `-v`) whether to prints additional logs about the current executed task.
 * `--dev` - whether to execute in the development mode. It means that the `@ckeditor/ckeditor5-package-tools` will not be installed from npm, but from the local file system.
 * `--use-npm` - whether to use `npm` to install dependencies in a newly created package.
-* `--use-yarn` - whether to use `yarn` to install dependencies in a newly created package. If `yarn` is installed globally it is used by default.
+* `--use-yarn` - whether to use `yarn` to install dependencies in a newly created package. This option is ignored if `yarn` is not installed.
 
 #### Developing the package
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ node /path/to/repository/packages/ckeditor5-package-generator <packageName> [--d
 * `--verbose` - (alias: `-v`) whether to prints additional logs about the current executed task.
 * `--dev` - whether to execute in the development mode. It means that the `@ckeditor/ckeditor5-package-tools` will not be installed from npm, but from the local file system.
 * `--use-npm` - whether to use `npm` to install dependencies in a newly created package.
-* `--use-yarn` - whether to use `yarn` to install dependencies in a newly created package. This option is ignored if `yarn` is not installed.
+* `--use-yarn` - whether to use `yarn` to install dependencies in a newly created package.
 
 #### Developing the package
 

--- a/packages/ckeditor5-package-generator/README.md
+++ b/packages/ckeditor5-package-generator/README.md
@@ -18,7 +18,7 @@ Due to the upcoming end of long-term support for `Node.js 12` in [April 2022](ht
 To create a new package, execute the following command:
 
 ```bash
-npx ckeditor5-package-generator <packageName> [--verbose] [--use-npm]
+npx ckeditor5-package-generator <packageName> [--verbose] [--use-npm] [--use-yarn]
 ```
 
 The `<packageName>` argument is required and must follow these rules:
@@ -31,4 +31,5 @@ As a result of executing the command, a new directory with a package will be cre
 ### Modifiers
 
 * `--verbose` &ndash; (alias: `-v`) whether to prints additional logs about the current executed task.
-* `--use-npm` &ndash; whether to use `npm` instead of `yarn` when installing dependencies in a newly created package.
+* `--use-npm` &ndash; whether to use `npm` to install dependencies in a newly created package.
+* `--use-yarn` &ndash; whether to use `yarn` to install dependencies in a newly created package. If `yarn` is installed globally it is used by default.

--- a/packages/ckeditor5-package-generator/README.md
+++ b/packages/ckeditor5-package-generator/README.md
@@ -32,4 +32,4 @@ As a result of executing the command, a new directory with a package will be cre
 
 * `--verbose` &ndash; (alias: `-v`) whether to prints additional logs about the current executed task.
 * `--use-npm` &ndash; whether to use `npm` to install dependencies in a newly created package.
-* `--use-yarn` &ndash; whether to use `yarn` to install dependencies in a newly created package. If `yarn` is installed globally it is used by default.
+* `--use-yarn` &ndash; whether to use `yarn` to install dependencies in a newly created package. This option is ignored if `yarn` is not installed.

--- a/packages/ckeditor5-package-generator/README.md
+++ b/packages/ckeditor5-package-generator/README.md
@@ -32,4 +32,4 @@ As a result of executing the command, a new directory with a package will be cre
 
 * `--verbose` &ndash; (alias: `-v`) whether to prints additional logs about the current executed task.
 * `--use-npm` &ndash; whether to use `npm` to install dependencies in a newly created package.
-* `--use-yarn` &ndash; whether to use `yarn` to install dependencies in a newly created package. This option is ignored if `yarn` is not installed.
+* `--use-yarn` &ndash; whether to use `yarn` to install dependencies in a newly created package.

--- a/packages/ckeditor5-package-generator/bin/index.js
+++ b/packages/ckeditor5-package-generator/bin/index.js
@@ -24,8 +24,8 @@ new Command( packageJson.name )
 		// Otherwise, the executable was downloaded from npm, and it can't be executed in dev-mode.
 		return fs.existsSync( path.join( rootRepositoryPath, '.git' ) );
 	}, false )
-	.option( '--use-npm', 'whether use npm to install packages' )
-	.option( '--use-yarn', 'whether use yarn to install packages' )
+	.option( '--use-npm', 'whether use npm to install packages', false )
+	.option( '--use-yarn', 'whether use yarn to install packages', false )
 	.option( '--lang <lang>', 'programming language to use' )
 	.allowUnknownOption()
 	.action( ( packageName, options ) => init( packageName, options ) )

--- a/packages/ckeditor5-package-generator/bin/index.js
+++ b/packages/ckeditor5-package-generator/bin/index.js
@@ -24,7 +24,8 @@ new Command( packageJson.name )
 		// Otherwise, the executable was downloaded from npm, and it can't be executed in dev-mode.
 		return fs.existsSync( path.join( rootRepositoryPath, '.git' ) );
 	}, false )
-	.option( '--use-npm', 'whether use npm to install packages', false )
+	.option( '--use-npm', 'whether use npm to install packages' )
+	.option( '--use-yarn', 'whether use yarn to install packages' )
 	.option( '--lang <lang>', 'programming language to use' )
 	.allowUnknownOption()
 	.action( ( packageName, options ) => init( packageName, options ) )

--- a/packages/ckeditor5-package-generator/lib/index.js
+++ b/packages/ckeditor5-package-generator/lib/index.js
@@ -18,6 +18,7 @@ const initializeGitRepository = require( './utils/initialize-git-repository' );
 const installDependencies = require( './utils/install-dependencies' );
 const installGitHooks = require( './utils/install-git-hooks' );
 const validatePackageName = require( './utils/validate-package-name' );
+const choosePackageManager = require( './utils/choose-package-manager' );
 
 /**
  * @param {String|undefined} packageName
@@ -25,18 +26,18 @@ const validatePackageName = require( './utils/validate-package-name' );
  */
 module.exports = async function init( packageName, options ) {
 	const logger = new Logger( options.verbose );
-	const program = options.useNpm ? 'npm' : 'yarn';
 
 	validatePackageName( logger, packageName );
 	const { directoryName, directoryPath } = createDirectory( logger, packageName );
+	const packageManager = await choosePackageManager( options );
 	const programmingLanguage = await chooseProgrammingLanguage( logger, options );
 	const packageVersions = getDependenciesVersions( logger, { devMode: options.dev } );
 	const dllConfiguration = getDllConfiguration( packageName );
 
 	copyFiles( logger, {
+		program: packageManager,
 		programmingLanguage,
 		packageName,
-		program,
 		directoryPath,
 		packageVersions,
 		dllConfiguration
@@ -57,7 +58,7 @@ module.exports = async function init( packageName, options ) {
 		'  * ' + chalk.underline( 'lint' ) + ' - for running a tool for static analyzing JavaScript files,',
 		'  * ' + chalk.underline( 'stylelint' ) + ' - for running a tool for static analyzing CSS files.',
 		'',
-		'Example: ' + chalk.gray( program + ' run start' ),
+		'Example: ' + chalk.gray( packageManager + ' run start' ),
 		''
 	].join( '\n' ), { startWithNewLine: true } );
 };
@@ -67,7 +68,9 @@ module.exports = async function init( packageName, options ) {
  *
  * @property {Boolean} [verbose=false]
  *
- * @property {Boolean} [useNpm=false]
+ * @property {Boolean} [useNpm]
+ *
+ * @property {Boolean} [useYarn]
  *
  * @property {Boolean} [dev=false]
  */

--- a/packages/ckeditor5-package-generator/lib/index.js
+++ b/packages/ckeditor5-package-generator/lib/index.js
@@ -29,7 +29,10 @@ module.exports = async function init( packageName, options ) {
 
 	validatePackageName( logger, packageName );
 	const { directoryName, directoryPath } = createDirectory( logger, packageName );
-	const packageManager = await choosePackageManager( options );
+	const packageManager = await choosePackageManager( {
+		isNpmFlagUsed: options.useNpm,
+		isYarnFlagUsed: options.useYarn
+	} );
 	const programmingLanguage = await chooseProgrammingLanguage( logger, options );
 	const packageVersions = getDependenciesVersions( logger, { devMode: options.dev } );
 	const dllConfiguration = getDllConfiguration( packageName );
@@ -43,7 +46,7 @@ module.exports = async function init( packageName, options ) {
 		dllConfiguration
 	} );
 
-	await installDependencies( directoryPath, options );
+	await installDependencies( directoryPath, options.verbose, packageManager, options.dev );
 	initializeGitRepository( directoryPath, logger );
 	await installGitHooks( directoryPath, logger, options );
 
@@ -68,9 +71,9 @@ module.exports = async function init( packageName, options ) {
  *
  * @property {Boolean} [verbose=false]
  *
- * @property {Boolean} [useNpm]
+ * @property {Boolean} [useNpm=false]
  *
- * @property {Boolean} [useYarn]
+ * @property {Boolean} [useYarn=false]
  *
  * @property {Boolean} [dev=false]
  */

--- a/packages/ckeditor5-package-generator/lib/utils/choose-package-manager.js
+++ b/packages/ckeditor5-package-generator/lib/utils/choose-package-manager.js
@@ -22,11 +22,15 @@ const YARN = 'yarn';
  * @returns {NPM|YARN}
  */
 module.exports = async function choosePackageManager( { useNpm = false, useYarn = false } = {} ) {
+	if ( !isYarnInstalled() ) {
+		return NPM;
+	}
+
 	if ( useNpm ) {
 		return NPM;
 	}
 
-	if ( useYarn || isYarnInstalled() ) {
+	if ( useYarn ) {
 		return YARN;
 	}
 
@@ -35,7 +39,7 @@ module.exports = async function choosePackageManager( { useNpm = false, useYarn 
 		name: 'packageManager',
 		message: 'Choose the package manager:',
 		type: 'list',
-		choices: [ NPM, YARN ]
+		choices: [ YARN, NPM ]
 	} ] );
 
 	return packageManager;

--- a/packages/ckeditor5-package-generator/lib/utils/choose-package-manager.js
+++ b/packages/ckeditor5-package-generator/lib/utils/choose-package-manager.js
@@ -1,0 +1,42 @@
+/**
+ * @license Copyright (c) 2020-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { prompt } = require( 'inquirer' );
+const isYarnInstalled = require( './is-yarn-installed' );
+
+const NPM = 'npm';
+const YARN = 'yarn';
+
+/**
+ * @typedef {Object} ChoosePackageManagerArgs
+ * @property {Boolean} useNpm
+ * @property {Boolean} useYarn
+ */
+
+/**
+ * @param {ChoosePackageManagerArgs} args
+ * @returns {NPM|YARN}
+ */
+module.exports = async function choosePackageManager( { useNpm = false, useYarn = false } = {} ) {
+	if ( useNpm ) {
+		return NPM;
+	}
+
+	if ( useYarn || isYarnInstalled() ) {
+		return YARN;
+	}
+
+	const { packageManager } = await prompt( [ {
+		prefix: '📍',
+		name: 'packageManager',
+		message: 'Choose the package manager:',
+		type: 'list',
+		choices: [ NPM, YARN ]
+	} ] );
+
+	return packageManager;
+};

--- a/packages/ckeditor5-package-generator/lib/utils/choose-package-manager.js
+++ b/packages/ckeditor5-package-generator/lib/utils/choose-package-manager.js
@@ -8,39 +8,48 @@
 const { prompt } = require( 'inquirer' );
 const isYarnInstalled = require( './is-yarn-installed' );
 
-const NPM = 'npm';
-const YARN = 'yarn';
+/**
+ * @param {{isNpmFlagUsed: Boolean, isYarnFlagUsed: Boolean}} args
+ * @returns {'npm'|'yarn'}
+ */
+module.exports = async function choosePackageManager( { isNpmFlagUsed, isYarnFlagUsed } ) {
+	const yarnInstalled = isYarnInstalled();
+
+	if ( isYarnFlagUsed && !yarnInstalled ) {
+		throw new Error( 'Detected --use-yarn option but yarn is not installed.' );
+	}
+
+	if ( isNpmFlagUsed && isYarnFlagUsed ) {
+		return await askUserToChoosePackageManager();
+	}
+
+	if ( !yarnInstalled ) {
+		return 'npm';
+	}
+
+	if ( isNpmFlagUsed ) {
+		return 'npm';
+	}
+
+	if ( isYarnFlagUsed ) {
+		return 'yarn';
+	}
+
+	return await askUserToChoosePackageManager();
+};
 
 /**
- * @typedef {Object} ChoosePackageManagerArgs
- * @property {Boolean} useNpm
- * @property {Boolean} useYarn
+ * @returns {'npm'|'yarn'}
  */
-
-/**
- * @param {ChoosePackageManagerArgs} args
- * @returns {NPM|YARN}
- */
-module.exports = async function choosePackageManager( { useNpm = false, useYarn = false } = {} ) {
-	if ( !isYarnInstalled() ) {
-		return NPM;
-	}
-
-	if ( useNpm ) {
-		return NPM;
-	}
-
-	if ( useYarn ) {
-		return YARN;
-	}
-
+async function askUserToChoosePackageManager() {
 	const { packageManager } = await prompt( [ {
 		prefix: '📍',
 		name: 'packageManager',
 		message: 'Choose the package manager:',
 		type: 'list',
-		choices: [ YARN, NPM ]
+		choices: [ 'yarn', 'npm' ]
 	} ] );
 
 	return packageManager;
-};
+}
+

--- a/packages/ckeditor5-package-generator/lib/utils/install-dependencies.js
+++ b/packages/ckeditor5-package-generator/lib/utils/install-dependencies.js
@@ -11,26 +11,30 @@ const { spawn } = require( 'child_process' );
 
 /**
  * @param {String} directoryPath
- * @param {CKeditor5PackageGeneratorOptions} options
+ * @param {Boolean} verbose
+ * @param {'npm'|'yarn'} packageManager
+ * @param {Boolean} isDevModeFlagUsed
  */
-module.exports = async function installDependencies( directoryPath, options ) {
+module.exports = async function installDependencies( directoryPath, verbose, packageManager, isDevModeFlagUsed ) {
 	const installSpinner = tools.createSpinner( 'Installing dependencies... ' + chalk.gray.italic( 'It takes a while.' ), {
-		isDisabled: options.verbose
+		isDisabled: verbose
 	} );
 
 	installSpinner.start();
 
-	await installPackages( directoryPath, options );
+	await installPackages( directoryPath, verbose, packageManager, isDevModeFlagUsed );
 
 	installSpinner.finish();
 };
 
 /**
  * @param {String} directoryPath
- * @param {CKeditor5PackageGeneratorOptions} options
+ * @param {Boolean} verbose
+ * @param {'npm'|'yarn'} packageManager
+ * @param {Boolean} isDevModeFlagUsed
  * @returns {Promise}
  */
-function installPackages( directoryPath, options ) {
+function installPackages( directoryPath, verbose, packageManager, isDevModeFlagUsed ) {
 	return new Promise( ( resolve, reject ) => {
 		const spawnOptions = {
 			encoding: 'utf8',
@@ -41,16 +45,21 @@ function installPackages( directoryPath, options ) {
 
 		let installTask;
 
-		if ( options.verbose ) {
+		if ( verbose ) {
 			spawnOptions.stdio = 'inherit';
 		}
 
-		if ( options.useNpm ) {
+		if ( packageManager === 'npm' ) {
 			const npmArguments = [
 				'install',
 				'--prefix',
 				directoryPath
 			];
+
+			// Flag required for npm 8 to install linked packages' dependencies
+			if ( isDevModeFlagUsed ) {
+				npmArguments.push( '--install-links' );
+			}
 
 			installTask = spawn( 'npm', npmArguments, spawnOptions );
 		} else {

--- a/packages/ckeditor5-package-generator/lib/utils/is-yarn-installed.js
+++ b/packages/ckeditor5-package-generator/lib/utils/is-yarn-installed.js
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2020-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { execSync } = require( 'child_process' );
+
+/**
+ * @returns {Boolean}
+ */
+module.exports = function isYarnInstalled() {
+	const result = execSync( 'yarn -v || echo false', { stdio: [ null, 'pipe', 'ihnerit' ] } );
+	return result.toString().trim() !== 'false';
+};

--- a/packages/ckeditor5-package-generator/lib/utils/is-yarn-installed.js
+++ b/packages/ckeditor5-package-generator/lib/utils/is-yarn-installed.js
@@ -11,6 +11,6 @@ const { execSync } = require( 'child_process' );
  * @returns {Boolean}
  */
 module.exports = function isYarnInstalled() {
-	const result = execSync( 'yarn -v || echo false', { stdio: [ null, 'pipe', 'ihnerit' ] } );
+	const result = execSync( 'yarn -v || echo false', { stdio: [ null, 'pipe', null ] } );
 	return result.toString().trim() !== 'false';
 };

--- a/packages/ckeditor5-package-generator/tests/index.js
+++ b/packages/ckeditor5-package-generator/tests/index.js
@@ -191,11 +191,8 @@ describe( 'lib/index', () => {
 
 		expect( stubs.installDependencies.callCount ).to.equal( 1 );
 		expect( stubs.installDependencies.getCall( 0 ).args[ 0 ] ).to.equal( 'directoryPath' );
-		expect( stubs.installDependencies.getCall( 0 ).args[ 1 ] ).to.deep.equal( {
-			verbose: false,
-			useNpm: false,
-			dev: false
-		} );
+		expect( stubs.installDependencies.getCall( 0 ).args[ 1 ] ).to.equal( false );
+		expect( stubs.installDependencies.getCall( 0 ).args[ 2 ] ).to.equal( 'yarn' );
 	} );
 
 	it( 'passes correct arguments to the initializeGitRepository()', async () => {
@@ -254,6 +251,6 @@ describe( 'lib/index', () => {
 
 		await index( packageName, options );
 
-		expect( stubs.choosePackageManager.calledWithMatch( { useNpm: true, useYarn: true } ) ).to.equal( true );
+		expect( stubs.choosePackageManager.calledWithMatch( { isNpmFlagUsed: true, isYarnFlagUsed: true } ) ).to.equal( true );
 	} );
 } );

--- a/packages/ckeditor5-package-generator/tests/utils/choose-package-manager.js
+++ b/packages/ckeditor5-package-generator/tests/utils/choose-package-manager.js
@@ -24,6 +24,8 @@ describe( 'lib/utils/choose-package-manager', () => {
 			isYarnInstalled: sinon.stub()
 		};
 
+		stubs.inquirer.prompt.resolves( { packageManager: 'yarn' } );
+
 		mockery.registerMock( './is-yarn-installed', stubs.isYarnInstalled );
 		mockery.registerMock( 'inquirer', stubs.inquirer );
 
@@ -39,31 +41,41 @@ describe( 'lib/utils/choose-package-manager', () => {
 	it( 'should return npm when npm argument is true and yarn is installed', async () => {
 		stubs.isYarnInstalled.returns( true );
 
-		const result = await choosePackageManager( { useNpm: true } );
+		const result = await choosePackageManager( { isNpmFlagUsed: true, isYarnFlagUsed: false } );
 
 		expect( result ).to.equal( 'npm' );
 	} );
 
-	it( 'should return npm when arguments are true and yarn is installed', async () => {
+	it( 'should call prompt when arguments are true and yarn is installed', async () => {
 		stubs.isYarnInstalled.returns( true );
 
-		const result = await choosePackageManager( { useNpm: true, useYarn: true } );
+		await choosePackageManager( { isNpmFlagUsed: true, isYarnFlagUsed: true } );
 
-		expect( result ).to.equal( 'npm' );
+		expect( stubs.inquirer.prompt.called ).to.equal( true );
+	} );
+
+	it( 'should throw error when yarn argument is true and yarn is not installed', async () => {
+		stubs.isYarnInstalled.returns( false );
+
+		try {
+			await choosePackageManager( { isNpmFlagUsed: false, isYarnFlagUsed: true } );
+		} catch ( e ) {
+			expect( e ).to.exist;
+		}
 	} );
 
 	it( 'should return yarn when yarn argument is true and yarn is installed', async () => {
 		stubs.isYarnInstalled.returns( true );
 
-		const result = await choosePackageManager( { useYarn: true } );
+		const result = await choosePackageManager( { isNpmFlagUsed: false, isYarnFlagUsed: true } );
 
 		expect( result ).to.equal( 'yarn' );
 	} );
 
-	it( 'should return npm when yarn is not installed even when useYarn argument is true', async () => {
+	it( 'should return npm when yarn is not installed and arguments false', async () => {
 		stubs.isYarnInstalled.returns( false );
 
-		const result = await choosePackageManager( { useYarn: true } );
+		const result = await choosePackageManager( { isNpmFlagUsed: false, isYarnFlagUsed: false } );
 
 		expect( result ).to.equal( 'npm' );
 	} );
@@ -72,17 +84,41 @@ describe( 'lib/utils/choose-package-manager', () => {
 		stubs.inquirer.prompt.resolves( { packageManager: 'yarn' } );
 		stubs.isYarnInstalled.returns( true );
 
-		const result = await choosePackageManager();
+		const result = await choosePackageManager( { isNpmFlagUsed: false, isYarnFlagUsed: false } );
 
 		expect( result ).to.equal( 'yarn' );
 	} );
 
 	it( 'should return npm when prompt returns npm, yarn is installed and arguments are false', async () => {
 		stubs.inquirer.prompt.resolves( { packageManager: 'npm' } );
-		stubs.isYarnInstalled.returns( false );
+		stubs.isYarnInstalled.returns( true );
 
-		const result = await choosePackageManager();
+		const result = await choosePackageManager( { isYarnFlagUsed: false, isNpmFlagUsed: false } );
 
 		expect( result ).to.equal( 'npm' );
+	} );
+
+	it( 'should not call prompt when yarn is not installed', async () => {
+		stubs.isYarnInstalled.returns( false );
+
+		await choosePackageManager( { isYarnFlagUsed: false, isNpmFlagUsed: false } );
+
+		expect( stubs.inquirer.prompt.called ).to.equal( false );
+	} );
+
+	it( 'should not call prompt when yarn is installed and npm flag used', async () => {
+		stubs.isYarnInstalled.returns( true );
+
+		await choosePackageManager( { isYarnFlagUsed: false, isNpmFlagUsed: true } );
+
+		expect( stubs.inquirer.prompt.called ).to.equal( false );
+	} );
+
+	it( 'should not call prompt when yarn is installed and yarn flag used', async () => {
+		stubs.isYarnInstalled.returns( true );
+
+		await choosePackageManager( { isYarnFlagUsed: true, isNpmFlagUsed: false } );
+
+		expect( stubs.inquirer.prompt.called ).to.equal( false );
 	} );
 } );

--- a/packages/ckeditor5-package-generator/tests/utils/choose-package-manager.js
+++ b/packages/ckeditor5-package-generator/tests/utils/choose-package-manager.js
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright (c) 2020-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const { expect } = require( 'chai' );
+const mockery = require( 'mockery' );
+const sinon = require( 'sinon' );
+
+describe( 'lib/utils/choose-package-manager', () => {
+	let stubs, choosePackageManager;
+
+	beforeEach( () => {
+		mockery.enable( {
+			useCleanCache: true,
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		} );
+
+		stubs = {
+			inquirer: {
+				prompt: sinon.stub()
+			},
+			isYarnInstalled: sinon.stub()
+		};
+
+		mockery.registerMock( './is-yarn-installed', stubs.isYarnInstalled );
+		mockery.registerMock( 'inquirer', stubs.inquirer );
+
+		choosePackageManager = require( '../../lib/utils/choose-package-manager' );
+	} );
+
+	afterEach( () => {
+		mockery.deregisterAll();
+		mockery.disable();
+		sinon.restore();
+	} );
+
+	it( 'should return npm when npm argument is true ', async () => {
+		const result = await choosePackageManager( { useNpm: true } );
+
+		expect( result ).to.equal( 'npm' );
+	} );
+
+	it( 'should return npm when npm and yarn arguments are true ', async () => {
+		const result = await choosePackageManager( { useNpm: true, useYarn: true } );
+
+		expect( result ).to.equal( 'npm' );
+	} );
+
+	it( 'should return yarn when yarn argument is true ', async () => {
+		const result = await choosePackageManager( { useYarn: true } );
+
+		expect( result ).to.equal( 'yarn' );
+	} );
+
+	it( 'should return yarn when isYarnInstalled returns true and arguments are false', async () => {
+		stubs.isYarnInstalled.returns( true );
+
+		const result = await choosePackageManager();
+
+		expect( result ).to.equal( 'yarn' );
+	} );
+
+	it( 'should return yarn when prompt returns yarn and isYarnInstalled and arguments are false', async () => {
+		stubs.inquirer.prompt.resolves( { packageManager: 'yarn' } );
+		stubs.isYarnInstalled.returns( false );
+
+		const result = await choosePackageManager();
+
+		expect( result ).to.equal( 'yarn' );
+	} );
+
+	it( 'should return npm when prompt returns npm and isYarnInstalled and arguments are false', async () => {
+		stubs.inquirer.prompt.resolves( { packageManager: 'npm' } );
+		stubs.isYarnInstalled.returns( false );
+
+		const result = await choosePackageManager();
+
+		expect( result ).to.equal( 'npm' );
+	} );
+} );

--- a/packages/ckeditor5-package-generator/tests/utils/choose-package-manager.js
+++ b/packages/ckeditor5-package-generator/tests/utils/choose-package-manager.js
@@ -36,25 +36,40 @@ describe( 'lib/utils/choose-package-manager', () => {
 		sinon.restore();
 	} );
 
-	it( 'should return npm when npm argument is true ', async () => {
+	it( 'should return npm when npm argument is true and yarn is installed', async () => {
+		stubs.isYarnInstalled.returns( true );
+
 		const result = await choosePackageManager( { useNpm: true } );
 
 		expect( result ).to.equal( 'npm' );
 	} );
 
-	it( 'should return npm when npm and yarn arguments are true ', async () => {
+	it( 'should return npm when arguments are true and yarn is installed', async () => {
+		stubs.isYarnInstalled.returns( true );
+
 		const result = await choosePackageManager( { useNpm: true, useYarn: true } );
 
 		expect( result ).to.equal( 'npm' );
 	} );
 
-	it( 'should return yarn when yarn argument is true ', async () => {
+	it( 'should return yarn when yarn argument is true and yarn is installed', async () => {
+		stubs.isYarnInstalled.returns( true );
+
 		const result = await choosePackageManager( { useYarn: true } );
 
 		expect( result ).to.equal( 'yarn' );
 	} );
 
-	it( 'should return yarn when isYarnInstalled returns true and arguments are false', async () => {
+	it( 'should return npm when yarn is not installed even when useYarn argument is true', async () => {
+		stubs.isYarnInstalled.returns( false );
+
+		const result = await choosePackageManager( { useYarn: true } );
+
+		expect( result ).to.equal( 'npm' );
+	} );
+
+	it( 'should return yarn when prompt returns yarn, yarn is installed and arguments are false', async () => {
+		stubs.inquirer.prompt.resolves( { packageManager: 'yarn' } );
 		stubs.isYarnInstalled.returns( true );
 
 		const result = await choosePackageManager();
@@ -62,16 +77,7 @@ describe( 'lib/utils/choose-package-manager', () => {
 		expect( result ).to.equal( 'yarn' );
 	} );
 
-	it( 'should return yarn when prompt returns yarn and isYarnInstalled and arguments are false', async () => {
-		stubs.inquirer.prompt.resolves( { packageManager: 'yarn' } );
-		stubs.isYarnInstalled.returns( false );
-
-		const result = await choosePackageManager();
-
-		expect( result ).to.equal( 'yarn' );
-	} );
-
-	it( 'should return npm when prompt returns npm and isYarnInstalled and arguments are false', async () => {
+	it( 'should return npm when prompt returns npm, yarn is installed and arguments are false', async () => {
 		stubs.inquirer.prompt.resolves( { packageManager: 'npm' } );
 		stubs.isYarnInstalled.returns( false );
 

--- a/packages/ckeditor5-package-generator/tests/utils/is-yarn-installed.js
+++ b/packages/ckeditor5-package-generator/tests/utils/is-yarn-installed.js
@@ -7,7 +7,7 @@ const { expect } = require( 'chai' );
 const mockery = require( 'mockery' );
 const sinon = require( 'sinon' );
 
-describe( 'lib/utils/choose-package-manager', () => {
+describe( 'lib/utils/is-yarn-installed', () => {
 	let stubs, isYarnInstalled;
 
 	beforeEach( () => {

--- a/packages/ckeditor5-package-generator/tests/utils/is-yarn-installed.js
+++ b/packages/ckeditor5-package-generator/tests/utils/is-yarn-installed.js
@@ -1,0 +1,48 @@
+/**
+ * @license Copyright (c) 2020-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const { expect } = require( 'chai' );
+const mockery = require( 'mockery' );
+const sinon = require( 'sinon' );
+
+describe( 'lib/utils/choose-package-manager', () => {
+	let stubs, isYarnInstalled;
+
+	beforeEach( () => {
+		mockery.enable( {
+			useCleanCache: true,
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		} );
+
+		stubs = {
+			childProcess: {
+				execSync: sinon.stub()
+			}
+		};
+
+		mockery.registerMock( 'child_process', stubs.childProcess );
+
+		isYarnInstalled = require( '../../lib/utils/is-yarn-installed' );
+	} );
+
+	afterEach( () => {
+		mockery.deregisterAll();
+		mockery.disable();
+		sinon.restore();
+	} );
+
+	it( 'should return true when yarn is installed', () => {
+		stubs.childProcess.execSync.returns( '1.23.45' );
+
+		expect( isYarnInstalled() ).to.equal( true );
+	} );
+
+	it( 'should return false when yarn is not installed', () => {
+		stubs.childProcess.execSync.returns( 'false' );
+
+		expect( isYarnInstalled() ).to.equal( false );
+	} );
+} );

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -69,8 +69,8 @@ start();
  * Runs checks and exits with an appropriate exit code.
  */
 async function start() {
-	await testBuild( 'js' );
-	await testBuild( 'ts' );
+	await testBuild( 'js', 'npm' );
+	await testBuild( 'ts', 'yarn' );
 
 	if ( foundError ) {
 		console.log( '\n' + chalk.red( 'Found errors during the verification. Please, review the log above.' ) );
@@ -80,21 +80,21 @@ async function start() {
 }
 
 /**
- * Build and run scripts for a given language.
+ * Build and run scripts for a given language and packageManager.
  *
  * @param {string} lang
+ * @param {'npm'|'yarn'} packageManager
  */
-async function testBuild( lang ) {
-	logProcess( `Testing build for language: [${ lang }].` );
+async function testBuild( lang, packageManager ) {
+	const packageManagerFlag = packageManager === 'npm' ? '--use-npm' : '--use-yarn';
+
+	logProcess( `Testing build for language: [${ lang }] and package manager: [${ packageManager }].` );
 
 	logProcess( 'Creating new package: "@ckeditor/ckeditor5-test-package"...' );
 	executeCommand( [
-		'node', 'packages/ckeditor5-package-generator/bin/index.js', '@ckeditor/ckeditor5-test-package',
-		'--dev', '--use-yarn', '--verbose', '--lang', lang
-	], { cwd: REPOSITORY_DIRECTORY } );
-
-	logProcess( 'Moving the package to temporary directory...' );
-	executeCommand( [ 'mv', 'ckeditor5-test-package', '..' ], { cwd: REPOSITORY_DIRECTORY } );
+		'node', 'ckeditor5-package-generator/packages/ckeditor5-package-generator/bin/index.js', '@ckeditor/ckeditor5-test-package',
+		'--dev', packageManagerFlag, '--verbose', '--lang', lang
+	], { cwd: path.join( REPOSITORY_DIRECTORY, '..' ) } );
 
 	logProcess( 'Executing tests...' );
 	executeCommand( [ 'yarn', 'run', 'test' ], { cwd: NEW_PACKAGE_DIRECTORY } );
@@ -132,7 +132,7 @@ async function testBuild( lang ) {
 		} )
 		.then( () => {
 			logProcess( 'Removing the created package...' );
-			fs.rmdirSync( NEW_PACKAGE_DIRECTORY, { recursive: true } );
+			fs.rmSync( NEW_PACKAGE_DIRECTORY, { recursive: true } );
 		} );
 }
 

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -90,7 +90,7 @@ async function testBuild( lang ) {
 	logProcess( 'Creating new package: "@ckeditor/ckeditor5-test-package"...' );
 	executeCommand( [
 		'node', 'packages/ckeditor5-package-generator/bin/index.js', '@ckeditor/ckeditor5-test-package',
-		'--dev', '--verbose', '--lang', lang
+		'--dev', '--use-yarn', '--verbose', '--lang', lang
 	], { cwd: REPOSITORY_DIRECTORY } );
 
 	logProcess( 'Moving the package to temporary directory...' );


### PR DESCRIPTION
Other (generator): Added `--use-yarn` flag to package generator to use yarn for installing dependencies in a newly created package. If npm and yarn are installed and no flags are set, user is prompted for a choice. Closes #120