### PR TITLE
Package tools will now support package names without organization prefix

### DIFF
--- a/packages/ckeditor5-package-tools/lib/tasks/translations-download.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/translations-download.js
@@ -22,7 +22,7 @@ module.exports = async options => {
 	}
 
 	const pkgJson = require( path.join( options.cwd, 'package.json' ) );
-	const packageName = pkgJson.name.split( '/' ).pop();
+	const packageName = pkgJson.name.includes( '/' ) ? pkgJson.name.split( '/' ).pop() : pkgJson.name;
 
 	return downloadTranslations( {
 		// Token used for authentication with the Transifex service.

--- a/packages/ckeditor5-package-tools/lib/tasks/translations-upload.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/translations-upload.js
@@ -22,7 +22,7 @@ module.exports = async options => {
 	}
 
 	const pkgJson = require( path.join( options.cwd, 'package.json' ) );
-	const packageName = pkgJson.name.split( '/' ).pop();
+	const packageName = pkgJson.name.includes( '/' ) ? pkgJson.name.split( '/' ).pop() : pkgJson.name;
 
 	return uploadPotFiles( {
 		// Token used for authentication with the Transifex service.

--- a/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-dll.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-dll.js
@@ -16,11 +16,12 @@ const { CKEditorTranslationsPlugin } = require( '@ckeditor/ckeditor5-dev-transla
 const { loaderDefinitions } = require( './webpack-utils' );
 
 module.exports = options => {
-	const packageJson = require( path.join( options.cwd, 'package.json' ) );
+	const pkgJson = require( path.join( options.cwd, 'package.json' ) );
 
 	// `dllName` is a short package name without the scope and the `ckeditor5-` prefix.
 	// E.g. for the package called `@ckeditor/ckeditor5-example-package`, the short name is `example-package`.
-	const dllName = packageJson.name.split( '/' )[ 1 ].replace( /^ckeditor5-/, '' );
+	const packageName = pkgJson.name.includes( '/' ) ? pkgJson.name.split( '/' ).pop() : pkgJson.name;
+	const dllName = packageName.replace( /^ckeditor5-/, '' );
 
 	// `dllWindowKey` is a name of a key which will be used for exposing the DLL library under
 	// the `window.CKEditor5` global variable. E.g. for the package called `@ckeditor/ckeditor5-example-package`,

--- a/packages/ckeditor5-package-tools/tests/tasks/translations-download.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/translations-download.js
@@ -48,7 +48,36 @@ describe( 'lib/tasks/translations-download', () => {
 		expect( translationsDownload ).to.be.a( 'function' );
 	} );
 
-	it( 'downloads translation files', async () => {
+	it( 'downloads translation files for package "ckeditor5-foo"', async () => {
+		mockery.registerMock( '/workspace/package.json', {
+			name: 'ckeditor5-foo'
+		} );
+
+		stubs.transifex.getToken.resolves( 'secretToken' );
+		stubs.transifex.downloadTranslations.resolves( 'OK' );
+
+		const results = await translationsDownload( {
+			cwd: '/workspace',
+			organization: 'foo',
+			project: 'bar'
+		} );
+
+		expect( results ).to.equal( 'OK' );
+
+		expect( stubs.transifex.downloadTranslations.calledOnce ).to.equal( true );
+		expect( stubs.transifex.downloadTranslations.firstCall.firstArg ).to.deep.equal( {
+			token: 'secretToken',
+			organizationName: 'foo',
+			projectName: 'bar',
+			cwd: '/workspace',
+			packages: new Map( [
+				[ 'ckeditor5-foo', '.' ]
+			] ),
+			simplifyLicenseHeader: true
+		} );
+	} );
+
+	it( 'downloads translation files for package "@ckeditor/ckeditor5-foo"', async () => {
 		stubs.transifex.getToken.resolves( 'secretToken' );
 		stubs.transifex.downloadTranslations.resolves( 'OK' );
 

--- a/packages/ckeditor5-package-tools/tests/tasks/translations-upload.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/translations-upload.js
@@ -48,7 +48,35 @@ describe( 'lib/tasks/translations-upload', () => {
 		expect( translationsUpload ).to.be.a( 'function' );
 	} );
 
-	it( 'uploads translation files', async () => {
+	it( 'uploads translation files for package "ckeditor5-foo"', async () => {
+		mockery.registerMock( '/workspace/package.json', {
+			name: 'ckeditor5-foo'
+		} );
+
+		stubs.transifex.getToken.resolves( 'secretToken' );
+		stubs.transifex.uploadPotFiles.resolves( 'OK' );
+
+		const results = await translationsUpload( {
+			cwd: '/workspace',
+			organization: 'foo',
+			project: 'bar'
+		} );
+
+		expect( results ).to.equal( 'OK' );
+
+		expect( stubs.transifex.uploadPotFiles.calledOnce ).to.equal( true );
+		expect( stubs.transifex.uploadPotFiles.firstCall.firstArg ).to.deep.equal( {
+			token: 'secretToken',
+			cwd: '/workspace',
+			organizationName: 'foo',
+			packages: new Map( [
+				[ 'ckeditor5-foo', 'tmp/.transifex/ckeditor5-foo' ]
+			] ),
+			projectName: 'bar'
+		} );
+	} );
+
+	it( 'uploads translation files for package "@ckeditor/ckeditor5-foo"', async () => {
 		stubs.transifex.getToken.resolves( 'secretToken' );
 		stubs.transifex.uploadPotFiles.resolves( 'OK' );
 

--- a/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-dll.js
+++ b/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-dll.js
@@ -175,6 +175,15 @@ describe( 'lib/utils/get-webpack-config-dll', () => {
 	} );
 
 	describe( 'verifying exposed DLL names', () => {
+		it( 'returns "foo" for a window key and a file name for the "ckeditor5-foo" package', () => {
+			stubs.packageJson.name = 'ckeditor5-foo';
+
+			const webpackConfig = getWebpackConfigDll( { cwd } );
+
+			expect( webpackConfig.output.filename ).to.equal( 'foo.js' );
+			expect( webpackConfig.output.library ).to.deep.equal( [ 'CKEditor5', 'foo' ] );
+		} );
+
 		it( 'returns "foo" for a window key and a file name for the "@ckeditor/ckeditor5-foo" package', () => {
 			const webpackConfig = getWebpackConfigDll( { cwd } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tools): Added support for package names without organization prefix. Closes #139.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
