### PR TITLE
Added missing ts-loader

### DIFF
--- a/packages/ckeditor5-package-generator/lib/utils/get-package-name-formats.js
+++ b/packages/ckeditor5-package-generator/lib/utils/get-package-name-formats.js
@@ -90,13 +90,13 @@ function uppercaseFirstChar( string ) {
 /**
  * @typedef {Object} FormattedName
  *
- * @property {String} raw: super-feature-name
+ * @property {String} raw super-feature-name
  *
- * @property {String} spacedOut Super plugin name
+ * @property {String} spacedOut Super feature name
  *
- * @property {String} camelCase superPluginName
+ * @property {String} camelCase superFeatureName
  *
- * @property {String} pascalCase SuperPluginName
+ * @property {String} pascalCase SuperFeatureName
  *
- * @property {String} lowerCaseMerged superpluginname
+ * @property {String} lowerCaseMerged superfeaturename
  */

--- a/packages/ckeditor5-package-tools/lib/utils/get-karma-config.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-karma-config.js
@@ -8,7 +8,9 @@
 /* eslint-env node */
 
 const path = require( 'path' );
-const { loaderDefinitions } = require( './webpack-utils' );
+const { loaderDefinitions, getModuleResolutionPaths } = require( './webpack-utils' );
+
+const PACKAGE_ROOT_DIR = path.join( __dirname, '..', '..' );
 
 /**
  * @param {Object} options
@@ -139,12 +141,15 @@ module.exports = options => {
  * @returns {Object}
  */
 function getWebpackConfiguration( options ) {
+	const moduleResolutionPaths = getModuleResolutionPaths( PACKAGE_ROOT_DIR );
+
 	const config = {
 		mode: 'development',
 
 		resolve: {
 			// Triple dots syntax allows extending default extension list instead of overwriting it.
-			extensions: [ '.ts', '...' ]
+			extensions: [ '.ts', '...' ],
+			modules: moduleResolutionPaths
 		},
 
 		module: {
@@ -156,9 +161,7 @@ function getWebpackConfiguration( options ) {
 		},
 
 		resolveLoader: {
-			modules: [
-				'node_modules'
-			]
+			modules: moduleResolutionPaths
 		}
 	};
 

--- a/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-dll.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-dll.js
@@ -13,7 +13,9 @@ const fs = require( 'fs' );
 const webpack = require( 'webpack' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const { CKEditorTranslationsPlugin } = require( '@ckeditor/ckeditor5-dev-translations' );
-const { loaderDefinitions } = require( './webpack-utils' );
+const { loaderDefinitions, getModuleResolutionPaths } = require( './webpack-utils' );
+
+const PACKAGE_ROOT_DIR = path.join( __dirname, '..', '..' );
 
 module.exports = options => {
 	const packageJson = require( path.join( options.cwd, 'package.json' ) );
@@ -58,6 +60,8 @@ module.exports = options => {
 	const entryFileName = fs.readdirSync( path.join( options.cwd, 'src' ) )
 		.find( filePath => /^index\.[jt]s$/.test( filePath ) );
 
+	const moduleResolutionPaths = getModuleResolutionPaths( PACKAGE_ROOT_DIR );
+
 	return {
 		mode: 'production',
 
@@ -90,7 +94,12 @@ module.exports = options => {
 
 		resolve: {
 			// Triple dots syntax allows extending default extension list instead of overwriting it.
-			extensions: [ '.ts', '...' ]
+			extensions: [ '.ts', '...' ],
+			modules: moduleResolutionPaths
+		},
+
+		resolveLoader: {
+			modules: moduleResolutionPaths
 		},
 
 		module: {

--- a/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-server.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-server.js
@@ -11,7 +11,9 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const { CKEditorTranslationsPlugin } = require( '@ckeditor/ckeditor5-dev-translations' );
-const { loaderDefinitions } = require( './webpack-utils' );
+const { loaderDefinitions, getModuleResolutionPaths } = require( './webpack-utils' );
+
+const PACKAGE_ROOT_DIR = path.join( __dirname, '..', '..' );
 
 module.exports = options => {
 	const webpackPlugins = [
@@ -35,6 +37,8 @@ module.exports = options => {
 
 	const entryFileName = fs.readdirSync( path.join( options.cwd, 'sample' ) )
 		.find( filePath => /^ckeditor\.[jt]s$/.test( filePath ) );
+
+	const moduleResolutionPaths = getModuleResolutionPaths( PACKAGE_ROOT_DIR );
 
 	return {
 		mode: options.production ? 'production' : 'development',
@@ -65,7 +69,12 @@ module.exports = options => {
 
 		resolve: {
 			// Triple dots syntax allows extending default extension list instead of overwriting it.
-			extensions: [ '.ts', '...' ]
+			extensions: [ '.ts', '...' ],
+			modules: moduleResolutionPaths
+		},
+
+		resolveLoader: {
+			modules: moduleResolutionPaths
 		},
 
 		module: {

--- a/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
@@ -64,5 +64,16 @@ module.exports = {
 				]
 			};
 		}
+	},
+	getModuleResolutionPaths: packageRootDir => {
+		return [
+			'node_modules',
+			//  Root of this package.
+			path.resolve( packageRootDir, 'node_modules' ),
+			// Root of the CPG repository.
+			path.resolve( packageRootDir, '..', '..', 'node_modules' ),
+			// Root of the repository that uses this package.
+			path.resolve( packageRootDir, '..', '..', '..', 'node_modules' )
+		];
 	}
 };

--- a/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
@@ -68,8 +68,10 @@ module.exports = {
 	getModuleResolutionPaths: packageRootDir => {
 		return [
 			'node_modules',
-			path.resolve( packageRootDir, '..', '..', 'node_modules' ),
-			path.resolve( packageRootDir, '..', '..', '..', 'node_modules' )
+			//  Root of this package.
+			path.resolve( packageRootDir, 'node_modules' ),
+			// Root of the CPG repository.
+			path.resolve( packageRootDir, '..', '..', 'node_modules' )
 		];
 	}
 };

--- a/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
@@ -68,7 +68,8 @@ module.exports = {
 	getModuleResolutionPaths: packageRootDir => {
 		return [
 			'node_modules',
-			path.resolve( packageRootDir, '..', '..', 'node_modules' )
+			path.resolve( packageRootDir, '..', '..', 'node_modules' ),
+			path.resolve( packageRootDir, '..', '..', '..', 'node_modules' )
 		];
 	}
 };

--- a/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
@@ -68,12 +68,7 @@ module.exports = {
 	getModuleResolutionPaths: packageRootDir => {
 		return [
 			'node_modules',
-			//  Root of this package.
-			path.resolve( packageRootDir, 'node_modules' ),
-			// Root of the CPG repository.
-			path.resolve( packageRootDir, '..', '..', 'node_modules' ),
-			// Root of the repository that uses this package.
-			path.resolve( packageRootDir, '..', '..', '..', 'node_modules' )
+			path.resolve( packageRootDir, '..', '..', 'node_modules' )
 		];
 	}
 };

--- a/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
@@ -68,10 +68,7 @@ module.exports = {
 	getModuleResolutionPaths: packageRootDir => {
 		return [
 			'node_modules',
-			//  Root of this package.
-			path.resolve( packageRootDir, 'node_modules' ),
-			// Root of the CPG repository.
-			path.resolve( packageRootDir, '..', '..', 'node_modules' )
+			path.resolve( packageRootDir, 'node_modules' )
 		];
 	}
 };

--- a/packages/ckeditor5-package-tools/package.json
+++ b/packages/ckeditor5-package-tools/package.json
@@ -40,6 +40,7 @@
     "stylelint": "^13.13.1",
     "stylelint-config-ckeditor5": "^2.0.1",
     "terser-webpack-plugin": "^3.0.2",
+    "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4",
     "webpack": "^5.58.1",

--- a/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-server.js
+++ b/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-server.js
@@ -8,6 +8,7 @@
 const mockery = require( 'mockery' );
 const sinon = require( 'sinon' );
 const expect = require( 'chai' ).expect;
+const path = require( 'path' );
 
 describe( 'lib/utils/get-webpack-config-server', () => {
 	let getWebpackConfigServer, stubs;
@@ -43,13 +44,15 @@ describe( 'lib/utils/get-webpack-config-server', () => {
 					raw: sinon.stub(),
 					styles: sinon.stub(),
 					typescript: sinon.stub()
-				}
+				},
+				getModuleResolutionPaths: sinon.stub()
 			}
 		};
 
 		stubs.webpackUtils.loaderDefinitions.raw.returns( 'raw-loader' );
 		stubs.webpackUtils.loaderDefinitions.typescript.returns( 'typescript-loader' );
 		stubs.webpackUtils.loaderDefinitions.styles.withArgs( cwd ).returns( 'styles-loader' );
+		stubs.webpackUtils.getModuleResolutionPaths.returns( 'loader-resolution-paths' );
 
 		stubs.fs.readdirSync.withArgs( '/process/cwd/sample' ).returns( [
 			'ckeditor.js',
@@ -97,6 +100,27 @@ describe( 'lib/utils/get-webpack-config-server', () => {
 		const config = getWebpackConfigServer( { cwd } );
 
 		expect( config.resolve.extensions ).to.deep.equal( [ '.ts', '...' ] );
+	} );
+
+	it( 'resolves correct module paths', () => {
+		const config = getWebpackConfigServer( { cwd } );
+
+		expect( config.resolve ).to.have.property( 'modules', 'loader-resolution-paths' );
+	} );
+
+	it( 'resolves correct loader paths', () => {
+		const config = getWebpackConfigServer( { cwd } );
+
+		expect( config.resolveLoader ).to.have.property( 'modules', 'loader-resolution-paths' );
+	} );
+
+	it( 'calls "getModuleResolutionPaths" with correct arguments', () => {
+		getWebpackConfigServer( { cwd } );
+
+		expect( stubs.webpackUtils.getModuleResolutionPaths.callCount ).to.equal( 1 );
+		const normalizedArgument = stubs.webpackUtils.getModuleResolutionPaths.firstCall.firstArg
+			.split( path.sep ).join( path.posix.sep );
+		expect( normalizedArgument.endsWith( '/packages/ckeditor5-package-tools/lib/utils/../..' ) ).to.equal( true );
 	} );
 
 	it( 'processes the "ckeditor.js" file', () => {

--- a/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
@@ -231,9 +231,18 @@ describe( 'lib/utils/webpack-utils', () => {
 		it( 'loads "node_modules" from root of the "ckeditor5-package-generator" repository', () => {
 			expect( moduleResolutionPaths[ 1 ] ).to.equal( 'root/directory/../../node_modules' );
 
-			expect( stubs.path.resolve.callCount ).to.equal( 1 );
+			expect( stubs.path.resolve.callCount ).to.equal( 2 );
 			expect( stubs.path.resolve.getCall( 0 ).args ).to.deep.equal(
 				[ 'root/directory', '..', '..', 'node_modules' ]
+			);
+		} );
+
+		it( 'loads "node_modules" from root of the repository that uses the "ckeditor5-package-tools" package', () => {
+			expect( moduleResolutionPaths[ 2 ] ).to.equal( 'root/directory/../../../node_modules' );
+
+			expect( stubs.path.resolve.callCount ).to.equal( 2 );
+			expect( stubs.path.resolve.getCall( 1 ).args ).to.deep.equal(
+				[ 'root/directory', '..', '..', '..', 'node_modules' ]
 			);
 		} );
 	} );

--- a/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
@@ -228,30 +228,12 @@ describe( 'lib/utils/webpack-utils', () => {
 			expect( moduleResolutionPaths[ 0 ] ).to.equal( 'node_modules' );
 		} );
 
-		it( 'loads "node_modules" from root of the "ckeditor5-package-tools" package', () => {
-			expect( moduleResolutionPaths[ 1 ] ).to.equal( 'root/directory/node_modules' );
-
-			expect( stubs.path.resolve.callCount ).to.equal( 3 );
-			expect( stubs.path.resolve.getCall( 0 ).args ).to.deep.equal(
-				[ 'root/directory', 'node_modules' ]
-			);
-		} );
-
 		it( 'loads "node_modules" from root of the "ckeditor5-package-generator" repository', () => {
-			expect( moduleResolutionPaths[ 2 ] ).to.equal( 'root/directory/../../node_modules' );
+			expect( moduleResolutionPaths[ 1 ] ).to.equal( 'root/directory/../../node_modules' );
 
-			expect( stubs.path.resolve.callCount ).to.equal( 3 );
-			expect( stubs.path.resolve.getCall( 1 ).args ).to.deep.equal(
+			expect( stubs.path.resolve.callCount ).to.equal( 1 );
+			expect( stubs.path.resolve.getCall( 0 ).args ).to.deep.equal(
 				[ 'root/directory', '..', '..', 'node_modules' ]
-			);
-		} );
-
-		it( 'loads "node_modules" from root of the repository that uses the "ckeditor5-package-tools" package', () => {
-			expect( moduleResolutionPaths[ 3 ] ).to.equal( 'root/directory/../../../node_modules' );
-
-			expect( stubs.path.resolve.callCount ).to.equal( 3 );
-			expect( stubs.path.resolve.getCall( 2 ).args ).to.deep.equal(
-				[ 'root/directory', '..', '..', '..', 'node_modules' ]
 			);
 		} );
 	} );

--- a/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
@@ -231,18 +231,9 @@ describe( 'lib/utils/webpack-utils', () => {
 		it( 'loads "node_modules" from root of the "ckeditor5-package-tools" package', () => {
 			expect( moduleResolutionPaths[ 1 ] ).to.equal( 'root/directory/node_modules' );
 
-			expect( stubs.path.resolve.callCount ).to.equal( 2 );
+			expect( stubs.path.resolve.callCount ).to.equal( 1 );
 			expect( stubs.path.resolve.getCall( 0 ).args ).to.deep.equal(
 				[ 'root/directory', 'node_modules' ]
-			);
-		} );
-
-		it( 'loads "node_modules" from root of the "ckeditor5-package-generator" repository', () => {
-			expect( moduleResolutionPaths[ 2 ] ).to.equal( 'root/directory/../../node_modules' );
-
-			expect( stubs.path.resolve.callCount ).to.equal( 2 );
-			expect( stubs.path.resolve.getCall( 1 ).args ).to.deep.equal(
-				[ 'root/directory', '..', '..', 'node_modules' ]
 			);
 		} );
 	} );

--- a/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
@@ -228,21 +228,21 @@ describe( 'lib/utils/webpack-utils', () => {
 			expect( moduleResolutionPaths[ 0 ] ).to.equal( 'node_modules' );
 		} );
 
-		it( 'loads "node_modules" from root of the "ckeditor5-package-generator" repository', () => {
-			expect( moduleResolutionPaths[ 1 ] ).to.equal( 'root/directory/../../node_modules' );
+		it( 'loads "node_modules" from root of the "ckeditor5-package-tools" package', () => {
+			expect( moduleResolutionPaths[ 1 ] ).to.equal( 'root/directory/node_modules' );
 
 			expect( stubs.path.resolve.callCount ).to.equal( 2 );
 			expect( stubs.path.resolve.getCall( 0 ).args ).to.deep.equal(
-				[ 'root/directory', '..', '..', 'node_modules' ]
+				[ 'root/directory', 'node_modules' ]
 			);
 		} );
 
-		it( 'loads "node_modules" from root of the repository that uses the "ckeditor5-package-tools" package', () => {
-			expect( moduleResolutionPaths[ 2 ] ).to.equal( 'root/directory/../../../node_modules' );
+		it( 'loads "node_modules" from root of the "ckeditor5-package-generator" repository', () => {
+			expect( moduleResolutionPaths[ 2 ] ).to.equal( 'root/directory/../../node_modules' );
 
 			expect( stubs.path.resolve.callCount ).to.equal( 2 );
 			expect( stubs.path.resolve.getCall( 1 ).args ).to.deep.equal(
-				[ 'root/directory', '..', '..', '..', 'node_modules' ]
+				[ 'root/directory', '..', '..', 'node_modules' ]
 			);
 		} );
 	} );

--- a/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
@@ -24,7 +24,8 @@ describe( 'lib/utils/webpack-utils', () => {
 
 		stubs = {
 			path: {
-				join: sinon.stub().callsFake( ( ...chunks ) => chunks.join( '/' ) )
+				join: sinon.stub().callsFake( ( ...chunks ) => chunks.join( '/' ) ),
+				resolve: sinon.stub().callsFake( ( ...chunks ) => chunks.join( '/' ) )
 			},
 			getThemePath: sinon.stub(),
 			devUtils: {
@@ -213,6 +214,45 @@ describe( 'lib/utils/webpack-utils', () => {
 				expect( '/Users/ckeditor/ckeditor5-foo/theme/icons/ckeditor.html' ).to.not.match( loader.test );
 				expect( 'C:\\Users\\ckeditor\\ckeditor5-foo\\theme\\icons\\ckeditor.html' ).to.not.match( loader.test );
 			} );
+		} );
+	} );
+
+	describe( 'getModuleResolutionPaths()', () => {
+		let moduleResolutionPaths;
+
+		beforeEach( () => {
+			moduleResolutionPaths = webpackUtils.getModuleResolutionPaths( 'root/directory' );
+		} );
+
+		it( 'loads "node_modules" directly', () => {
+			expect( moduleResolutionPaths[ 0 ] ).to.equal( 'node_modules' );
+		} );
+
+		it( 'loads "node_modules" from root of the "ckeditor5-package-tools" package', () => {
+			expect( moduleResolutionPaths[ 1 ] ).to.equal( 'root/directory/node_modules' );
+
+			expect( stubs.path.resolve.callCount ).to.equal( 3 );
+			expect( stubs.path.resolve.getCall( 0 ).args ).to.deep.equal(
+				[ 'root/directory', 'node_modules' ]
+			);
+		} );
+
+		it( 'loads "node_modules" from root of the "ckeditor5-package-generator" repository', () => {
+			expect( moduleResolutionPaths[ 2 ] ).to.equal( 'root/directory/../../node_modules' );
+
+			expect( stubs.path.resolve.callCount ).to.equal( 3 );
+			expect( stubs.path.resolve.getCall( 1 ).args ).to.deep.equal(
+				[ 'root/directory', '..', '..', 'node_modules' ]
+			);
+		} );
+
+		it( 'loads "node_modules" from root of the repository that uses the "ckeditor5-package-tools" package', () => {
+			expect( moduleResolutionPaths[ 3 ] ).to.equal( 'root/directory/../../../node_modules' );
+
+			expect( stubs.path.resolve.callCount ).to.equal( 3 );
+			expect( stubs.path.resolve.getCall( 2 ).args ).to.deep.equal(
+				[ 'root/directory', '..', '..', '..', 'node_modules' ]
+			);
 		} );
 	} );
 } );

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -70,7 +70,9 @@ start();
  */
 async function start() {
 	await testBuild( 'js', 'npm' );
-	await testBuild( 'ts', 'yarn', 'CustomPluginName400' );
+	await testBuild( 'ts', 'npm', 'CustomPluginName' );
+	await testBuild( 'js', 'yarn', 'customPluginName400' );
+	await testBuild( 'ts', 'yarn' );
 
 	if ( foundError ) {
 		console.log( '\n' + chalk.red( 'Found errors during the verification. Please, review the log above.' ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tools): Added the missing `ts-loader`. Webpack missed it when creating a new package using `npm` as the package manager. Closes #143.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
