### PR TITLE
Add `augmentation.ts` to the TypeScript package generator.

### DIFF
--- a/packages/ckeditor5-package-generator/lib/templates/ts/sample/index.html
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/sample/index.html
@@ -72,6 +72,7 @@
 │  └─ ckeditor.ts      # The editor initialization script.
 ├─ src
 │  ├─ <%= formattedNames.plugin.lowerCaseMerged %>.ts
+│  ├─ augmentation.ts  # Type augmentations for the `@ckeditor/ckeditor5-core` module. Read more in <a href="https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginsMap.html">PlugginsMap</a> and <a href="https://ckeditor.com/docs/ckeditor5/latest/api/module_core_commandcollection-CommandsMap.html">CommandsMap</a>.
 │  ├─ index.ts         # The modules exported by the package when using the DLL builds.
 │  └─ **/*.ts          # All TypeScript source files should be saved here.
 ├─ tests

--- a/packages/ckeditor5-package-generator/lib/templates/ts/sample/index.html
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/sample/index.html
@@ -72,7 +72,7 @@
 │  └─ ckeditor.ts      # The editor initialization script.
 ├─ src
 │  ├─ <%= formattedNames.plugin.lowerCaseMerged %>.ts
-│  ├─ augmentation.ts  # Type augmentations for the `@ckeditor/ckeditor5-core` module. Read more in <a href="https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginsMap.html">PlugginsMap</a> and <a href="https://ckeditor.com/docs/ckeditor5/latest/api/module_core_commandcollection-CommandsMap.html">CommandsMap</a>.
+│  ├─ augmentation.ts  # Type augmentations for the `@ckeditor/ckeditor5-core` module. Read more in <a href="https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginsMap.html">PluginsMap</a> and <a href="https://ckeditor.com/docs/ckeditor5/latest/api/module_core_commandcollection-CommandsMap.html">CommandsMap</a>.
 │  ├─ index.ts         # The modules exported by the package when using the DLL builds.
 │  └─ **/*.ts          # All TypeScript source files should be saved here.
 ├─ tests

--- a/packages/ckeditor5-package-generator/lib/templates/ts/src/_PLACEHOLDER_.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/src/_PLACEHOLDER_.ts.txt
@@ -1,5 +1,6 @@
 import { Plugin } from 'ckeditor5/src/core';
 import { ButtonView } from 'ckeditor5/src/ui';
+import './augmentation';
 
 import ckeditor5Icon from '../theme/icons/ckeditor.svg';
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/src/_PLACEHOLDER_.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/src/_PLACEHOLDER_.ts.txt
@@ -1,6 +1,5 @@
 import { Plugin } from 'ckeditor5/src/core';
 import { ButtonView } from 'ckeditor5/src/ui';
-import './augmentation';
 
 import ckeditor5Icon from '../theme/icons/ckeditor.svg';
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/src/augmentation.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/src/augmentation.ts.txt
@@ -1,0 +1,7 @@
+import type { <%= formattedNames.plugin.pascalCase %> } from './index';
+
+declare module '@ckeditor/ckeditor5-core' {
+	interface PluginsMap {
+		[ <%= formattedNames.plugin.pascalCase %>.pluginName ]: <%= formattedNames.plugin.pascalCase %>;
+	}
+}

--- a/packages/ckeditor5-package-generator/lib/templates/ts/src/index.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/src/index.ts.txt
@@ -1,4 +1,5 @@
 import ckeditor from './../theme/icons/ckeditor.svg';
+import './augmentation';
 
 export { default as <%= formattedNames.plugin.pascalCase %> } from './<%= formattedNames.plugin.lowerCaseMerged %>';
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/tsconfig.json.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/tsconfig.json.txt
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "lib": [
-      "DOM"
+      "DOM",
+      "DOM.Iterable"
     ],
     "noImplicitAny": true,
     "noImplicitOverride": true,

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -33,8 +33,10 @@ const EXPECTED_PUBLISH_FILES = {
 		'ckeditor5-metadata.json'
 	],
 	ts: [
+		'src/augmentation.js',
 		'src/index.js',
 		'src/testpackage.js',
+		'src/augmentation.d.ts',
 		'src/index.d.ts',
 		'src/testpackage.d.ts',
 
@@ -55,6 +57,7 @@ const EXPECTED_SRC_DIR_FILES = {
 		'testpackage.js'
 	],
 	ts: [
+		'augmentation.ts',
 		'index.ts',
 		'testpackage.ts'
 	]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add `augmentation.ts` to the TypeScript package generator. Closes ckeditor/ckeditor5-package-generator#144.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
