### PR TITLE
Added option to check version of the generator

### DIFF
--- a/packages/ckeditor5-package-generator/bin/index.js
+++ b/packages/ckeditor5-package-generator/bin/index.js
@@ -29,5 +29,7 @@ new Command( packageJson.name )
 	.option( '--lang <lang>', 'programming language to use' )
 	.option( '--plugin-name <name>', 'optional custom plugin name' )
 	.allowUnknownOption()
+	.version( packageJson.version )
+	.addHelpText( 'after', `\nVersion: ${ packageJson.version }` )
 	.action( ( packageName, options ) => init( packageName, options ) )
 	.parse( process.argv );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (generator): The tool will now display its version when used with `-V`/`--version` option. The version will also be displayed on the `-h`/`--help` message. Closes #150.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
