### PR TITLE
Space in a path does not crash the generator

### DIFF
--- a/packages/ckeditor5-package-generator/lib/utils/install-dependencies.js
+++ b/packages/ckeditor5-package-generator/lib/utils/install-dependencies.js
@@ -52,9 +52,7 @@ function installPackages( directoryPath, packageManager, verbose, dev ) {
 
 		if ( packageManager === 'npm' ) {
 			const npmArguments = [
-				'install',
-				'--prefix',
-				directoryPath
+				'install'
 			];
 
 			// Flag required for npm 8 to install linked packages' dependencies
@@ -64,12 +62,7 @@ function installPackages( directoryPath, packageManager, verbose, dev ) {
 
 			installTask = spawn( 'npm', npmArguments, spawnOptions );
 		} else {
-			const yarnArguments = [
-				'--cwd',
-				directoryPath
-			];
-
-			installTask = spawn( 'yarnpkg', yarnArguments, spawnOptions );
+			installTask = spawn( 'yarnpkg', [], spawnOptions );
 		}
 
 		installTask.on( 'close', exitCode => {

--- a/packages/ckeditor5-package-generator/tests/utils/install-dependencies.js
+++ b/packages/ckeditor5-package-generator/tests/utils/install-dependencies.js
@@ -79,10 +79,7 @@ describe( 'lib/utils/install-dependencies', () => {
 		expect( stubs.childProcess.spawn.callCount ).to.equal( 1 );
 		expect( stubs.childProcess.spawn.getCall( 0 ).args ).to.deep.equal( [
 			'yarnpkg',
-			[
-				'--cwd',
-				defaultDirectoryPath
-			],
+			[],
 			{
 				encoding: 'utf8',
 				shell: true,
@@ -98,10 +95,7 @@ describe( 'lib/utils/install-dependencies', () => {
 		expect( stubs.childProcess.spawn.callCount ).to.equal( 1 );
 		expect( stubs.childProcess.spawn.getCall( 0 ).args ).to.deep.equal( [
 			'yarnpkg',
-			[
-				'--cwd',
-				defaultDirectoryPath
-			],
+			[],
 			{
 				encoding: 'utf8',
 				shell: true,
@@ -119,9 +113,7 @@ describe( 'lib/utils/install-dependencies', () => {
 		expect( stubs.childProcess.spawn.getCall( 0 ).args ).to.deep.equal( [
 			'npm',
 			[
-				'install',
-				'--prefix',
-				defaultDirectoryPath
+				'install'
 			],
 			{
 				encoding: 'utf8',
@@ -139,9 +131,7 @@ describe( 'lib/utils/install-dependencies', () => {
 		expect( stubs.childProcess.spawn.getCall( 0 ).args ).to.deep.equal( [
 			'npm',
 			[
-				'install',
-				'--prefix',
-				defaultDirectoryPath
+				'install'
 			],
 			{
 				encoding: 'utf8',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (generator): Removed the current working directory from a package manager command when installing dependencies. A new process is already spawned in the directory. Hence, there is no need to duplicate the path. Thanks to that, a space in the path will not crash the generator while installing dependencies. Closes #156.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
