### PR TITLE
Use the `@latest` release when looking for CKEditor 5 version

### DIFF
--- a/packages/ckeditor5-package-generator/lib/utils/get-package-version.js
+++ b/packages/ckeditor5-package-generator/lib/utils/get-package-version.js
@@ -5,24 +5,14 @@
 
 'use strict';
 
-const { spawnSync } = require( 'child_process' );
+const { execSync } = require( 'child_process' );
 
 /**
- * Returns the version of the specified package.
+ * Returns version of the specified package.
  *
  * @param packageName Name of the package to check the version of.
  * @return {String}
  */
 module.exports = function getPackageVersion( packageName ) {
-	// See: #39.
-	const response = spawnSync( 'npm', [ 'view', packageName, '--json' ], {
-		encoding: 'utf8',
-		shell: true
-	} );
-
-	try {
-		return JSON.parse( response.stdout.toString() ).versions.pop();
-	} catch ( err ) {
-		throw new Error( 'The specified package has not been published on npm yet.' );
-	}
+	return execSync( `npm view ${ packageName } version` ).toString().trim();
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (generator): When generating a new package, the generator uses the latest stable CKEditor 5 release. Closes #155.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
