### PR TITLE
Fixed path to `ckeditor5-package-generator` that is different on CI than locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,18 @@ jobs:
       - run:
           name: Run unit tests
           command: yarn run coverage
+      - run:
+          name: Verify build (JavaScript, npm)
+          command: node scripts/ci/verify-build -l js -p npm
+      - run:
+          name: Verify build (TypeScript, npm, custom plugin name)
+          command: node scripts/ci/verify-build -l ts -p npm -n CustomPluginName
+      - run:
+          name: Verify build (JavaScript, yarn, custom plugin name)
+          command: node scripts/ci/verify-build -l js -p yarn -n customPluginName400
+      - run:
+          name: Verify build (TypeScript, yarn)
+          command: node scripts/ci/verify-build -l ts -p yarn
       - unless:
           # Upload the code coverage results for non-nightly builds only.
           condition: << pipeline.parameters.isNightly >>
@@ -91,18 +103,6 @@ jobs:
             - run:
                 name: Upload code coverage
                 command: cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
-      - run:
-          name: Verify build (JavaScript, npm)
-          command: node scripts/ci/verify-build -l js -p npm
-      - run:
-          name: Verify build (TypeScript, npm, custom plugin name)
-          command: node scripts/ci/verify-build -l ts -p npm -n CustomPluginName
-      - run:
-          name: Verify build (JavaScript, yarn, custom plugin name)
-          command: node scripts/ci/verify-build -l js -p yarn -n customPluginName400
-      - run:
-          name: Verify build (TypeScript, yarn)
-          command: node scripts/ci/verify-build -l ts -p yarn
 
 workflows:
   version: 2

--- a/scripts/ci/verify-build.js
+++ b/scripts/ci/verify-build.js
@@ -91,8 +91,10 @@ async function start() {
  */
 async function verifyBuild( { language, packageManager, customPluginName } ) {
 	let testSetupInfoMessage = `Testing build for language: [${ language }] and package manager: [${ packageManager }]`;
+
+	const projectRootName = path.basename( process.cwd() );
 	const packageBuildCommand = [
-		'node', 'ckeditor5-package-generator/packages/ckeditor5-package-generator/bin/index.js', '@ckeditor/ckeditor5-test-package',
+		'node', `${ projectRootName }/packages/ckeditor5-package-generator/bin/index.js`, '@ckeditor/ckeditor5-test-package',
 		'--dev', '--verbose', '--lang', language, `--use-${ packageManager }`
 	];
 
@@ -208,7 +210,7 @@ function startDevelopmentServer( cwd ) {
 		// Webpack prints the "hidden modules..." string when finished processing the file.
 		// Hence, we can assume that the server is live at this stage.
 		sampleServer.stdout.on( 'data', data => {
-			const content = data.toString().slice( 0, -1 );
+			const content = stripAnsiEscapeCodes( data.toString() ).slice( 0, -1 );
 			const endMatch = /webpack \d+\.\d+\.\d+ compiled successfully in \d+ ms/.test( content );
 
 			if ( endMatch ) {
@@ -233,7 +235,7 @@ function startDevelopmentServer( cwd ) {
  */
 function startDevelopmentServerForDllBuild( cwd ) {
 	return new Promise( ( resolve, reject ) => {
-		const sampleServer = spawn( 'http-server', [ './' ], {
+		const sampleServer = spawn( 'npx', [ 'http-server', './' ], {
 			cwd,
 			encoding: 'utf8',
 			shell: true


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed script that creates test build on CI where the path to `ckeditor5-package-generator` is different than locally.

Internal: Fixed incorrect launching of the dev server on CI.

Internal: Changed sending the coverage status to be the last step on CI.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
