### PR TITLE
Node version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "upath": "^2.0.1"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",

--- a/packages/ckeditor5-package-generator/lib/templates/js/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/js/package.json
@@ -14,7 +14,7 @@
   "main": "src/index.js",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0",
+    "node": ">=18.0.0",
     "npm": ">=5.7.1"
   },
   "files": [

--- a/packages/ckeditor5-package-generator/lib/templates/ts/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/package.json
@@ -14,7 +14,7 @@
   "main": "src/index.ts",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0",
+    "node": ">=18.0.0",
     "npm": ">=5.7.1"
   },
   "files": [

--- a/packages/ckeditor5-package-generator/package.json
+++ b/packages/ckeditor5-package-generator/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://ckeditor.com/ckeditor-5",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^38.0.0",


### PR DESCRIPTION
Other: Updated the required version of Node.js to 18. See ckeditor/ckeditor5#14924.

MAJOR BREAKING CHANGE: Upgraded the minimal versions of Node.js to `18.0.0` due to the end of LTS.