### PR TITLE
Support for prereleases released via CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ Before you start, you need to prepare the changelog entries.
 1. Make sure the `#master` branch is up-to-date: `git fetch && git checkout master && git pull`.
 1. Prepare a release branch: `git checkout -b release-[YYYYMMDD]` where `YYYYMMDD` is the current day.
 1. Generate the changelog entries: `yarn run changelog --branch release-[YYYYMMDD] [--from [GIT_TAG]]`.
-	* By default, the changelog generator uses the latest published tag as a starting point for collecting commits to process.
+    * By default, the changelog generator uses the latest published tag as a starting point for collecting commits to process.
 
-	  The `--from` modifier option allows overriding the default behavior. It is required when preparing the changelog entries for the next stable release while the previous one was marked as a prerelease, e.g., `@alpha`.
+      The `--from` modifier option allows overriding the default behavior. It is required when preparing the changelog entries for the next stable release while the previous one was marked as a prerelease, e.g., `@alpha`.
 
-	  **Example**: Let's assume that the `v40.5.0-alpha.0` tag is our latest and that we want to release it on a stable channel. The `--from` modifier should be equal to `--from v40.4.0`.
-	* This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
-	* Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
+      **Example**: Let's assume that the `v40.5.0-alpha.0` tag is our latest and that we want to release it on a stable channel. The `--from` modifier should be equal to `--from v40.4.0`.
+    * This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
+    * Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
 1. Commit all changes and prepare a new pull request targeting the `#master` branch.
 1. Ping the `@ckeditor/ckeditor-5-devops` team to review the pull request and trigger the release process.
 

--- a/README.md
+++ b/README.md
@@ -111,15 +111,17 @@ Now, the newly created package uses changes from the local repository.
 
 ## Releasing packages
 
-The release process is automated via CircleCI and it can release both channels: stable (`X.Y.Z`) and pre-releases (`X.Y.Z-alpha.X`, etc.).
+CircleCI automates the release process and can release both channels: stable (`X.Y.Z`) and pre-releases (`X.Y.Z-alpha.X`, etc.).
 
 Before you start, you need to prepare the changelog entries.
 
 1. Make sure the `#master` branch is up-to-date: `git fetch && git checkout master && git pull`.
-1. Prepare a release branch: `git checkout -b release-[YYYY-MM-DD]` where `YYYY-MM-DD` is the current day.
-1. Generate the changelog entries: `yarn run changelog --branch release-[YYYY-MM-DD] [--from [GIT_TAG]]`.
+1. Prepare a release branch: `git checkout -b release-[YYYYMMDD]` where `YYYYMMDD` is the current day.
+1. Generate the changelog entries: `yarn run changelog --branch release-[YYYYMMDD] [--from [GIT_TAG]]`.
 	* By default, the changelog generator uses the latest published tag as a starting point for collecting commits to process.
+
 	  The `--from` modifier option allows overriding the default behavior. It is required when preparing the changelog entries for the next stable release while the previous one was marked as a prerelease, e.g., `@alpha`.
+
 	  **Example**: Let's assume that the `v40.5.0-alpha.0` tag is our latest and that we want to release it on a stable channel. The `--from` modifier should be equal to `--from v40.4.0`.
 	* This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
 	* Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.

--- a/README.md
+++ b/README.md
@@ -111,15 +111,20 @@ Now, the newly created package uses changes from the local repository.
 
 ## Releasing packages
 
-This package's release process is automated via CircleCI. Before you start a new release, you'll need to prepare the changelog entries.
+The release process is automated via CircleCI and it can release both channels: stable (`X.Y.Z`) and pre-releases (`X.Y.Z-alpha.X`, etc.).
+
+Before you start, you need to prepare the changelog entries.
 
 1. Make sure the `#master` branch is up-to-date: `git fetch && git checkout master && git pull`.
 1. Prepare a release branch: `git checkout -b release-[YYYY-MM-DD]` where `YYYY-MM-DD` is the current day.
-1. Generate the changelog entries: `yarn run changelog --branch release-[YYYY-MM-DD]`.
-    * This task checks what changed in each package and bumps the version accordingly. If nothing changes at all, it won't create a new changelog entry. If changes were irrelevant (e.g., only dependencies), it would make an "internal changes" entry.
-    * Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
+1. Generate the changelog entries: `yarn run changelog --branch release-[YYYY-MM-DD] [--from [GIT_TAG]]`.
+	* By default, the changelog generator uses the latest published tag as a starting point for collecting commits to process.
+	  The `--from` modifier option allows overriding the default behavior. It is required when preparing the changelog entries for the next stable release while the previous one was marked as a prerelease, e.g., `@alpha`.
+	  **Example**: Let's assume that the `v40.5.0-alpha.0` tag is our latest and that we want to release it on a stable channel. The `--from` modifier should be equal to `--from v40.4.0`.
+	* This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
+	* Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
 1. Commit all changes and prepare a new pull request targeting the `#master` branch.
-1. Ping the @ckeditor/ckeditor-5-devops team to review the pull request and trigger the release process.
+1. Ping the `@ckeditor/ckeditor-5-devops` team to review the pull request and trigger the release process.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@ckeditor/ckeditor5-dev-bump-year": "^40.0.1",
         "@ckeditor/ckeditor5-dev-ci": "^40.0.1",
-        "@ckeditor/ckeditor5-dev-release-tools": "^40.0.1",
+        "@ckeditor/ckeditor5-dev-release-tools": "^40.5.0",
         "@ckeditor/ckeditor5-dev-web-crawler": "^40.0.1",
         "chalk": "^4.1.2",
         "coveralls": "^3.1.1",
@@ -468,12 +468,12 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-release-tools": {
-      "version": "40.3.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-release-tools/-/ckeditor5-dev-release-tools-40.3.1.tgz",
-      "integrity": "sha512-GOfJvuJI2FOpKG6seDX8OfhAKeZ7+Aq8rLy+msS3fTbg+Um/GN3Itp74/4FO9eIaMmJGq9J+QkTytg16YjyGSg==",
+      "version": "40.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-release-tools/-/ckeditor5-dev-release-tools-40.5.0.tgz",
+      "integrity": "sha512-FsZxwBqUrZFxO2jbZ0E0wHxJln0jebLC5YQgG9Q5haylTqooCQDQiiPheMoLAlCur2ZqbHYrWhqj0mV2Z7jZ2w==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-dev-utils": "^40.3.1",
+        "@ckeditor/ckeditor5-dev-utils": "^40.5.0",
         "@octokit/rest": "^19.0.0",
         "chalk": "^4.0.0",
         "cli-columns": "^4.0.0",
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-translations": {
-      "version": "40.3.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-40.3.1.tgz",
-      "integrity": "sha512-PgGVIz2seENB8RlM3GSPvsqMCiHAll4r4F4xXjmfSEZY+H7OK9ImiXbhpV+jzi2A3eoyJ49VZyaIGx6edM8jew==",
+      "version": "40.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-40.5.0.tgz",
+      "integrity": "sha512-oYTpZAchobqYjeWX5v2Awhg8HRZ6UKiFNc7CeSvfm4l3krJPO4NAxfNZrdRwT4pCn4mz9zovfUvJlb2oWVEQxQ==",
       "dependencies": {
         "@babel/parser": "^7.18.9",
         "@babel/traverse": "^7.18.9",
@@ -539,11 +539,11 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-utils": {
-      "version": "40.3.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-utils/-/ckeditor5-dev-utils-40.3.1.tgz",
-      "integrity": "sha512-hTEdh0TbSEQmlL0d1inZ8sRfiyDEdoJ0shZKridCw/Egs76lL6WoPkMUkGIl9ApLGIs48S+xx0OMBDzvzrrMpQ==",
+      "version": "40.5.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-utils/-/ckeditor5-dev-utils-40.5.0.tgz",
+      "integrity": "sha512-O8Fb7M9BIwI59xIK0/cnVG3u5OK2k2US3Q8rphnwfxWItmOPAnnt8zZt5Kpsa3Rbpe/kIIi5BOgOOjZO8dFHdw==",
       "dependencies": {
-        "@ckeditor/ckeditor5-dev-translations": "^40.3.1",
+        "@ckeditor/ckeditor5-dev-translations": "^40.5.0",
         "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.6.1",
@@ -18030,6 +18030,8 @@
     },
     "packages/ckeditor5-package-generator/node_modules/commander": {
       "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -18037,6 +18039,8 @@
     },
     "packages/ckeditor5-package-generator/node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -18055,6 +18059,8 @@
     },
     "packages/ckeditor5-package-generator/node_modules/inquirer": {
       "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
@@ -18100,6 +18106,8 @@
     },
     "packages/ckeditor5-package-generator/node_modules/rxjs": {
       "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -18162,6 +18170,8 @@
     },
     "packages/ckeditor5-package-generator/node_modules/tslib": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "license": "0BSD"
     },
     "packages/ckeditor5-package-generator/node_modules/watchpack": {
@@ -18232,6 +18242,8 @@
     },
     "packages/ckeditor5-package-generator/node_modules/wrap-ansi": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -18509,6 +18521,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/ansi-colors": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18516,6 +18530,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/ansi-regex": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18523,6 +18539,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -18533,6 +18551,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -18555,6 +18575,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/chalk": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -18567,6 +18589,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/chalk/node_modules/supports-color": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -18577,6 +18601,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/chokidar": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.1",
@@ -18596,6 +18622,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/cliui": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^3.1.0",
@@ -18605,6 +18633,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/color-convert": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -18612,10 +18642,14 @@
     },
     "packages/ckeditor5-package-tools/node_modules/color-name": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "license": "MIT"
     },
     "packages/ckeditor5-package-tools/node_modules/debug": {
       "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -18623,6 +18657,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/debug/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "packages/ckeditor5-package-tools/node_modules/define-lazy-prop": {
@@ -18638,6 +18674,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/diff": {
       "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -18645,10 +18683,14 @@
     },
     "packages/ckeditor5-package-tools/node_modules/emoji-regex": {
       "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "license": "MIT"
     },
     "packages/ckeditor5-package-tools/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -18656,6 +18698,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/find-up": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
@@ -18666,6 +18710,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/flat": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "is-buffer": "~2.0.3"
@@ -18676,6 +18722,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/fsevents": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18687,6 +18735,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/glob": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -18702,6 +18752,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/glob/node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -18712,6 +18764,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/has-flag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18741,6 +18795,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18762,6 +18818,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/jest-worker": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -18774,6 +18832,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/jest-worker/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18781,6 +18841,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -18794,6 +18856,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/js-yaml": {
       "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -18818,6 +18882,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/locate-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
@@ -18829,6 +18895,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/log-symbols": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^2.4.2"
@@ -18857,6 +18925,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -18867,6 +18937,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/mkdirp": {
       "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
@@ -18877,6 +18949,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/mocha": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "3.2.3",
@@ -18918,6 +18992,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/ms": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "license": "MIT"
     },
     "packages/ckeditor5-package-tools/node_modules/object.assign": {
@@ -18953,6 +19029,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -18966,6 +19044,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/p-locate": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
@@ -18992,6 +19072,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/path-exists": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18999,6 +19081,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/readdirp": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.0.4"
@@ -19067,6 +19151,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/serialize-javascript": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -19074,6 +19160,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/string-width": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^7.0.1",
@@ -19086,6 +19174,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/strip-ansi": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
@@ -19096,6 +19186,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -19103,6 +19195,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/supports-color": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -19113,6 +19207,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/terser-webpack-plugin": {
       "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+      "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.20",
@@ -19423,6 +19519,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -19433,6 +19531,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/wrap-ansi": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.0",
@@ -19465,10 +19565,14 @@
     },
     "packages/ckeditor5-package-tools/node_modules/y18n": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
     },
     "packages/ckeditor5-package-tools/node_modules/yargs": {
       "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^5.0.0",
@@ -19485,6 +19589,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/yargs-parser": {
       "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
@@ -19493,6 +19599,8 @@
     },
     "packages/ckeditor5-package-tools/node_modules/yargs-unparser": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
       "license": "MIT",
       "dependencies": {
         "flat": "^4.1.0",

--- a/scripts/ci/is-project-ready-to-release.js
+++ b/scripts/ci/is-project-ready-to-release.js
@@ -9,36 +9,18 @@
 
 'use strict';
 
-const { execSync } = require( 'child_process' );
 const releaseTools = require( '@ckeditor/ckeditor5-dev-release-tools' );
-const semver = require( 'semver' );
-const { name } = require( '../../packages/ckeditor5-package-generator/package.json' );
+const { name: packageName } = require( '../../packages/ckeditor5-package-generator/package.json' );
 
-const latestPublishedVersion = execSync( `npm view ${ name }@latest version`, { encoding: 'utf-8' } ).trim();
 const changelogVersion = releaseTools.getLastFromChangelog();
+const npmTag = releaseTools.getNpmTagFromVersion( changelogVersion );
 
-if ( getVersionTag( changelogVersion ) !== 'latest' ) {
-	console.log( `Aborting due non-latest changelog version (${ changelogVersion }).` );
-	process.exit( 1 );
-}
-
-if ( semver.lte( changelogVersion, latestPublishedVersion ) ) {
-	console.log(
-		`The proposed changelog (${ changelogVersion }) version is not greater than the published one (${ latestPublishedVersion }).`
-	);
-	process.exit( 1 );
-}
-
-console.log( 'The project is ready to release.' );
-
-/**
- * Returns an npm tag based on the specified release version.
- *
- * @param {String} version
- * @returns {String}
- */
-function getVersionTag( version ) {
-	const [ versionTag ] = semver.prerelease( version ) || [ 'latest' ];
-
-	return versionTag;
-}
+releaseTools.isVersionPublishableForTag( packageName, changelogVersion, npmTag )
+	.then( result => {
+		if ( !result ) {
+			console.error( `The proposed changelog (${ changelogVersion }) version is not higher than the already published one.` );
+			process.exit( 1 );
+		} else {
+			console.log( 'The project is ready to release.' );
+		}
+	} );

--- a/scripts/release/publishpackages.js
+++ b/scripts/release/publishpackages.js
@@ -22,6 +22,10 @@ const versionChangelog = releaseTools.getChangesForVersion( latestVersion );
 
 let githubToken;
 
+if ( !cliArguments.npmTag ) {
+	cliArguments.npmTag = releaseTools.getNpmTagFromVersion( latestVersion );
+}
+
 const tasks = new Listr( [
 	{
 		title: 'Publishing packages.',

--- a/scripts/release/utils/parsearguments.js
+++ b/scripts/release/utils/parsearguments.js
@@ -30,7 +30,7 @@ module.exports = function parseArguments( cliArguments ) {
 		default: {
 			packages: null,
 			branch: 'master',
-			'npm-tag': 'latest',
+			'npm-tag': null,
 			ci: false,
 			'compile-only': false,
 			verbose: false
@@ -59,7 +59,7 @@ module.exports = function parseArguments( cliArguments ) {
 /**
  * @typedef {Object} ReleaseOptions
  *
- * @property {String} [npmTag='latest']
+ * @property {String|null} [npmTag=null]
  *
  * @property {Array.<String>|null} packages
  *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Support for releasing the repository for prereleases.

---

### Additional information

Part of https://github.com/cksource/ckeditor5-internal/issues/3710.

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
