### PR TITLE
fix: Change getThemePath to support mono repos

### DIFF
--- a/packages/ckeditor5-package-tools/lib/utils/get-theme-path.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-theme-path.js
@@ -7,20 +7,14 @@
 
 /* eslint-env node */
 
-const path = require( 'path' );
-
 /**
  * Returns an absolute path to the main file of the `@ckeditor/ckeditor5-theme-lark` package.
  *
- * The function does the same as what does `require.resolve()`. However, there is no option for mocking it in tests,
- * hence the value is obtained manually.
+ * Used to assist mocking require.resolve() in tests.
  *
- * @param {String} cwd
+ * @param {Function} resolver
  * @return {String}
  */
-module.exports = function getThemePath( cwd ) {
-	const packagePath = path.join( cwd, 'node_modules', '@ckeditor', 'ckeditor5-theme-lark' );
-	const packageJson = require( path.join( packagePath, 'package.json' ) );
-
-	return path.join( packagePath, packageJson.main );
+module.exports = function getThemePath( resolver ) {
+	return resolver( '@ckeditor/ckeditor5-theme-lark' );
 };

--- a/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
@@ -45,7 +45,7 @@ module.exports = {
 			};
 		},
 
-		styles: cwd => {
+		styles: () => {
 			return {
 				test: /\.css$/,
 				use: [
@@ -64,7 +64,7 @@ module.exports = {
 						options: {
 							postcssOptions: getPostCssConfig( {
 								themeImporter: {
-									themePath: getThemePath( cwd )
+									themePath: getThemePath( require.resolve )
 								},
 								minify: true
 							} )

--- a/packages/ckeditor5-package-tools/tests/utils/get-theme-path.js
+++ b/packages/ckeditor5-package-tools/tests/utils/get-theme-path.js
@@ -10,9 +10,7 @@ const sinon = require( 'sinon' );
 const expect = require( 'chai' ).expect;
 
 describe( 'lib/utils/get-theme-path', () => {
-	let getThemePath, stubs;
-
-	const cwd = '/process/cwd';
+	let getThemePath;
 
 	beforeEach( () => {
 		mockery.enable( {
@@ -20,19 +18,6 @@ describe( 'lib/utils/get-theme-path', () => {
 			warnOnReplace: false,
 			warnOnUnregistered: false
 		} );
-
-		stubs = {
-			packageJson: {
-				name: '@ckeditor/ckeditor5-theme-lark',
-				main: './theme/theme.css'
-			},
-			path: {
-				join: sinon.stub().callsFake( ( ...chunks ) => chunks.join( '/' ).replace( '/./', '/' ) )
-			}
-		};
-
-		mockery.registerMock( 'path', stubs.path );
-		mockery.registerMock( '/process/cwd/node_modules/@ckeditor/ckeditor5-theme-lark/package.json', stubs.packageJson );
 
 		getThemePath = require( '../../lib/utils/get-theme-path' );
 	} );
@@ -46,7 +31,8 @@ describe( 'lib/utils/get-theme-path', () => {
 		expect( getThemePath ).to.be.a( 'function' );
 	} );
 
-	it( 'returns an absolute path to an entry file of the "@ckeditor/ckeditor5-theme-lark" package', () => {
-		expect( getThemePath( cwd ) ).to.equal( '/process/cwd/node_modules/@ckeditor/ckeditor5-theme-lark/theme/theme.css' );
+	it( 'resolves the "@ckeditor/ckeditor5-theme-lark" package', () => {
+		const resolver = packageName => packageName;
+		expect( getThemePath( resolver ) ).to.equal( '@ckeditor/ckeditor5-theme-lark' );
 	} );
 } );

--- a/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
@@ -177,7 +177,8 @@ describe( 'lib/utils/webpack-utils', () => {
 			// Webpack processes loaders from the bottom, to the top. Hence, "postcss-loader" will be called as the first one.
 			it( 'uses "postcss-loader" for processing CKEditor 5 assets', () => {
 				expect( stubs.getThemePath.calledOnce ).to.equal( true );
-				expect( stubs.getThemePath.firstCall.args[ 0 ] ).to.equal( '/process/cwd' );
+				expect( typeof stubs.getThemePath.firstCall.args[ 0 ] == 'function' ).to.equal( true );
+				expect( stubs.getThemePath.firstCall.args[ 0 ].prototype.constructor.name ).to.equal( 'resolve' );
 
 				expect( stubs.devUtils.styles.getPostCssConfig.calledOnce ).to.equal( true );
 				expect( stubs.devUtils.styles.getPostCssConfig.firstCall.firstArg ).to.deep.equal( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Support generated packages located in a mono-repo. Closes #132 .

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
