### PR TITLE
Change the path to the types in the `package.json` in `ts` templates.

### DIFF
--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/package.json
@@ -19,7 +19,7 @@
       "import": "./src/index.js"
     },
     "./dist/index.js": {
-      "types": "./dist/types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./translations/*.js": {

--- a/packages/ckeditor5-package-generator/lib/templates/ts/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/package.json
@@ -13,10 +13,10 @@
   "type": "module",
   "main": "dist/index.ts",
   "module": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./translations/*.js": {

--- a/scripts/ci/utils/expectedFiles.js
+++ b/scripts/ci/utils/expectedFiles.js
@@ -62,8 +62,8 @@ const EXPECTED_TS_LEGACY_PUBLISH_FILES = [
 ];
 
 const EXPECTED_DIST_TYPES_PUBLISH_FILES = [
-	'dist/types/augmentation.d.ts',
-	'dist/types/index.d.ts'
+	'dist/augmentation.d.ts',
+	'dist/index.d.ts'
 ];
 
 const EXPECTED_PUBLISH_FILES = {

--- a/scripts/ci/verify-build.js
+++ b/scripts/ci/verify-build.js
@@ -62,7 +62,7 @@ async function verifyBuild( { language, packageManager, customPluginName, instal
 		( supportsLegacyMethods ?
 			EXPECTED_LEGACY_PUBLISH_FILES :
 			EXPECTED_PUBLISH_FILES
-		).ts.push( `dist/types/${ fileName }.d.ts` );
+		).ts.push( `dist/${ fileName }.d.ts` );
 	}
 
 	const expectedPublishFiles = getExpectedFiles(


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (generator): Change the path to the types in the `package.json`  in `ts` templates. See https://github.com/ckeditor/ckeditor5/issues/16684.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
