### PR TITLE
Update the `exports` field in `package.json` templates to fix issues with loading CSS and translations in older bundlers.

### DIFF
--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/package.json
@@ -16,11 +16,8 @@
   "exports": {
     ".": "./src/index.js",
     "./dist/index.js": "./dist/index.js",
-    "./translations/*.js": {
-      "types": "./dist/translations/*.d.ts",
-      "import": "./dist/translations/*.js"
-    },
-    "./*.css": "./dist/*.css",
+    "./*": "./dist/*",
+    "./browser/*": null,
     "./build/*": "./build/*",
 		"./src/*": "./src/*",
     "./package.json": "./package.json"

--- a/packages/ckeditor5-package-generator/lib/templates/js/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/js/package.json
@@ -15,11 +15,8 @@
   "module": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./translations/*.js": {
-      "types": "./dist/translations/*.d.ts",
-      "import": "./dist/translations/*.js"
-    },
-    "./*.css": "./dist/*.css",
+    "./*": "./dist/*",
+    "./browser/*": null,
     "./package.json": "./package.json"
   },
   "license": "MIT",

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/package.json
@@ -22,11 +22,8 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./translations/*.js": {
-      "types": "./dist/translations/*.d.ts",
-      "import": "./dist/translations/*.js"
-    },
-    "./*.css": "./dist/*.css",
+		"./*": "./dist/*",
+    "./browser/*": null,
     "./build/*": "./build/*",
 		"./src/*": "./src/*",
     "./package.json": "./package.json"

--- a/packages/ckeditor5-package-generator/lib/templates/ts/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/package.json
@@ -19,11 +19,8 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./translations/*.js": {
-      "types": "./dist/translations/*.d.ts",
-      "import": "./dist/translations/*.js"
-    },
-    "./*.css": "./dist/*.css",
+    "./*": "./dist/*",
+    "./browser/*": null,
     "./package.json": "./package.json"
   },
   "license": "MIT",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (generator): Update the `exports` field in `package.json` templates to fix issues with loading CSS and translations in older bundlers. See https://github.com/ckeditor/ckeditor5/issues/16638.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
