### PR TITLE
Each package template should have own `README.md` based on what commands can be execute in it.

### DIFF
--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/README.md
@@ -151,7 +151,7 @@ Download translations from the Transifex server. Depending on users' activity in
 
 The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+To avoid passing the `--transifex` option whenever you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/README.md
@@ -21,11 +21,11 @@ This package was created by the [ckeditor5-package-generator](https://www.npmjs.
 
 ## Developing the package
 
-To read about the CKEditor 5 framework, visit the [CKEditor5 documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
+To read about the CKEditor 5 Framework, visit the [CKEditor 5 Framework documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
 
 ## Available scripts
 
-Npm scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
 
 All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
 
@@ -33,7 +33,7 @@ The following scripts are available in the package.
 
 ### `start`
 
-Starts a HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
+Starts an HTTP server with the live-reload mechanism that allows previewing and testing of plugins available in the package.
 
 When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
 
@@ -106,7 +106,7 @@ npm run build:dist
 
 ### `dll:build`
 
-Creates a DLL-compatible package build which can be loaded into an editor using [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
+Creates a DLL-compatible package build that can be loaded into an editor using [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
 
 Examples:
 
@@ -147,11 +147,11 @@ Examples:
 
 ### `translations:download`
 
-Download translations from the Transifex server. Depending on users' activity in the project, it creates translations files used for building the editor.
+Download translations from the Transifex server. Depending on users' activity in the project, it creates translation files used for building the editor.
 
 The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when calls the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/README.md
@@ -1,0 +1,180 @@
+<%= packageName %>
+<% print( '='.repeat( packageName.length ) ) %>
+
+This package was created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package.
+
+## Table of contents
+
+* [Developing the package](#developing-the-package)
+* [Available scripts](#available-scripts)
+  * [`start`](#start)
+  * [`test`](#test)
+  * [`lint`](#lint)
+  * [`stylelint`](#stylelint)
+  * [`build:dist`](#builddist)
+  * [`dll:build`](#dllbuild)
+  * [`dll:serve`](#dllserve)
+  * [`translations:collect`](#translationscollect)
+  * [`translations:download`](#translationsdownload)
+  * [`translations:upload`](#translationsupload)
+* [License](#license)
+
+## Developing the package
+
+To read about the CKEditor 5 framework, visit the [CKEditor5 documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
+
+## Available scripts
+
+Npm scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+
+All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
+
+The following scripts are available in the package.
+
+### `start`
+
+Starts a HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
+
+When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
+
+You can also define the language that will translate the created editor by specifying the `--language [LANG]` option. It defaults to `'en'`.
+
+Examples:
+
+```bash
+# Starts the server and open the browser.
+<%= packageManager %> run start
+
+# Disable auto-opening the browser.
+<%= packageManager %> run start <%= cliSeparator %>--no-open
+
+# Create the editor with the interface in German.
+<%= packageManager %> run start <%= cliSeparator %>--language=de
+```
+
+### `test`
+
+Allows executing unit tests for the package, specified in the `tests/` directory. The command accepts the following modifiers:
+
+* `--coverage` &ndash; to create the code coverage report,
+* `--watch` &ndash; to observe the source files (the command does not end after executing tests),
+* `--source-map` &ndash; to generate source maps of sources,
+* `--verbose` &ndash; to print additional webpack logs.
+
+Examples:
+
+```bash
+# Execute tests.
+<%= packageManager %> run test
+
+# Generate code coverage report after each change in the sources.
+<%= packageManager %> run test <%= cliSeparator %>--coverage --test
+```
+
+### `lint`
+
+Runs ESLint, which analyzes the code (all `*.<%= programmingLanguage %>` files) to quickly find problems.
+
+Examples:
+
+```bash
+# Execute eslint.
+<%= packageManager %> run lint
+```
+
+### `stylelint`
+
+Similar to the `lint` task, stylelint analyzes the CSS code (`*.css` files in the `theme/` directory) in the package.
+
+Examples:
+
+```bash
+# Execute stylelint.
+<%= packageManager %> run stylelint
+```
+
+### `build:dist`
+
+Creates npm and browser builds of your plugin. These builds can be added to the editor by following the [Configuring CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/configuration.html) guide.
+
+Examples:
+
+```bash
+# Builds the `npm` and browser files thats are ready to publish.
+npm run build:dist
+```
+
+### `dll:build`
+
+Creates a DLL-compatible package build which can be loaded into an editor using [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
+
+Examples:
+
+```bash
+# Build the DLL file that is ready to publish.
+<%= packageManager %> run dll:build
+
+# Build the DLL file and listen to changes in its sources.
+<%= packageManager %> run dll:build <%= cliSeparator %>--watch
+```
+
+### `dll:serve`
+
+Creates a simple HTTP server (without the live-reload mechanism) that allows verifying whether the DLL build of the package is compatible with the CKEditor 5 [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
+
+Examples:
+
+```bash
+# Starts the HTTP server and opens the browser.
+<%= packageManager %> run dll:serve
+```
+
+### `translations:collect`
+
+Collects translation messages (arguments of the `t()` function) and context files, then validates whether the provided values do not interfere with the values specified in the `@ckeditor/ckeditor5-core` package.
+
+The task may end with an error if one of the following conditions is met:
+
+* Found the `Unused context` error &ndash; entries specified in the `lang/contexts.json` file are not used in source files. They should be removed.
+* Found the `Context is duplicated for the id` error &ndash; some of the entries are duplicated. Consider removing them from the `lang/contexts.json` file, or rewrite them.
+* Found the `Context for the message id is missing` error &ndash; entries specified in source files are not described in the `lang/contexts.json` file. They should be added.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:collect
+```
+
+### `translations:download`
+
+Download translations from the Transifex server. Depending on users' activity in the project, it creates translations files used for building the editor.
+
+The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
+
+To avoid passing the `--transifex` option every time when calls the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:download <%= cliSeparator %>--transifex [API URL]
+```
+
+### `translations:upload`
+
+Uploads translation messages onto the Transifex server. It allows for the creation of translations into other languages by users using the Transifex platform.
+
+The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
+
+To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:upload <%= cliSeparator %>--transifex [API URL]
+```
+
+## License
+
+The `<%= packageName %>` package is available under [MIT license](https://opensource.org/licenses/MIT).
+
+However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and it can be changed.

--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/README.md
@@ -25,7 +25,7 @@ To read about the CKEditor 5 Framework, visit the [CKEditor 5 Framework document
 
 ## Available scripts
 
-NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with people contributing to the project. It ensures developers use the same command with the same options (flags).
 
 All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
 
@@ -35,7 +35,7 @@ The following scripts are available in the package.
 
 Starts an HTTP server with the live-reload mechanism that allows previewing and testing of plugins available in the package.
 
-When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
+When the server starts, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
 
 You can also define the language that will translate the created editor by specifying the `--language [LANG]` option. It defaults to `'en'`.
 
@@ -54,7 +54,7 @@ Examples:
 
 ### `test`
 
-Allows executing unit tests for the package, specified in the `tests/` directory. The command accepts the following modifiers:
+Allows executing unit tests for the package specified in the `tests/` directory. The command accepts the following modifiers:
 
 * `--coverage` &ndash; to create the code coverage report,
 * `--watch` &ndash; to observe the source files (the command does not end after executing tests),
@@ -95,7 +95,7 @@ Examples:
 
 ### `build:dist`
 
-Creates npm and browser builds of your plugin. These builds can be added to the editor by following the [Configuring CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/configuration.html) guide.
+Creates npm and browser builds of your plugin. These builds can be added to the editor following the [Configuring CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/configuration.html) guide.
 
 Examples:
 
@@ -161,11 +161,11 @@ Examples:
 
 ### `translations:upload`
 
-Uploads translation messages onto the Transifex server. It allows for the creation of translations into other languages by users using the Transifex platform.
+Uploads translation messages onto the Transifex server. It allows users to create translations into other languages using the Transifex platform.
 
 The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
+To avoid passing the `--transifex` option whenever you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
 
 Examples:
 
@@ -177,4 +177,4 @@ Examples:
 
 The `<%= packageName %>` package is available under [MIT license](https://opensource.org/licenses/MIT).
 
-However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and it can be changed.
+However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and can be changed.

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -123,7 +123,7 @@ Download translations from the Transifex server. Depending on users' activity in
 
 The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+To avoid passing the `--transifex` option whenever you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -22,7 +22,7 @@ This package was created by the [ckeditor5-package-generator](https://www.npmjs.
 To read about the CKEditor 5 Framework, visit the [CKEditor 5 Framework documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
 
 ## Available scripts
-NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with people contributing to the project. It ensures developers use the same command with the same options (flags).
 
 All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
 

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -51,7 +51,7 @@ Examples:
 
 ### `test`
 
-Allows executing unit tests for the package, specified in the `tests/` directory. The command accepts the following modifiers:
+Allows executing unit tests for the package specified in the `tests/` directory. The command accepts the following modifiers:
 
 * `--coverage` &ndash; to create the code coverage report,
 * `--watch` &ndash; to observe the source files (the command does not end after executing tests),

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -32,7 +32,7 @@ The following scripts are available in the package.
 
 Starts an HTTP server with the live-reload mechanism that allows previewing and testing of plugins available in the package.
 
-When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
+When the server starts, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
 
 You can also define the language that will translate the created editor by specifying the `--language [LANG]` option. It defaults to `'en'`.
 

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -19,11 +19,10 @@ This package was created by the [ckeditor5-package-generator](https://www.npmjs.
 
 ## Developing the package
 
-To read about the CKEditor 5 framework, visit the [CKEditor5 documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
+To read about the CKEditor 5 Framework, visit the [CKEditor 5 Framework documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
 
 ## Available scripts
-
-Npm scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
 
 All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
 
@@ -31,7 +30,7 @@ The following scripts are available in the package.
 
 ### `start`
 
-Starts a HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
+Starts an HTTP server with the live-reload mechanism that allows previewing and testing of plugins available in the package.
 
 When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
 
@@ -109,7 +108,7 @@ Collects translation messages (arguments of the `t()` function) and context file
 The task may end with an error if one of the following conditions is met:
 
 * Found the `Unused context` error &ndash; entries specified in the `lang/contexts.json` file are not used in source files. They should be removed.
-* Found the `Context is duplicated for the id` error &ndash; some of the entries are duplicated. Consider removing them from the `lang/contexts.json` file, or rewrite them.
+* Found the `Context is duplicated for the id` error &ndash; some of the entries are duplicated. Consider removing them from the `lang/contexts.json` file, or rewriting them.
 * Found the `Context for the message id is missing` error &ndash; entries specified in source files are not described in the `lang/contexts.json` file. They should be added.
 
 Examples:
@@ -120,11 +119,11 @@ Examples:
 
 ### `translations:download`
 
-Download translations from the Transifex server. Depending on users' activity in the project, it creates translations files used for building the editor.
+Download translations from the Transifex server. Depending on users' activity in the project, it creates translation files used for building the editor.
 
 The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when calls the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -1,0 +1,153 @@
+<%= packageName %>
+<% print( '='.repeat( packageName.length ) ) %>
+
+This package was created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package.
+
+## Table of contents
+
+* [Developing the package](#developing-the-package)
+* [Available scripts](#available-scripts)
+  * [`start`](#start)
+  * [`test`](#test)
+  * [`lint`](#lint)
+  * [`stylelint`](#stylelint)
+  * [`build:dist`](#builddist)
+  * [`translations:collect`](#translationscollect)
+  * [`translations:download`](#translationsdownload)
+  * [`translations:upload`](#translationsupload)
+* [License](#license)
+
+## Developing the package
+
+To read about the CKEditor 5 framework, visit the [CKEditor5 documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
+
+## Available scripts
+
+Npm scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+
+All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
+
+The following scripts are available in the package.
+
+### `start`
+
+Starts a HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
+
+When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
+
+You can also define the language that will translate the created editor by specifying the `--language [LANG]` option. It defaults to `'en'`.
+
+Examples:
+
+```bash
+# Starts the server and open the browser.
+<%= packageManager %> run start
+
+# Disable auto-opening the browser.
+<%= packageManager %> run start <%= cliSeparator %>--no-open
+
+# Create the editor with the interface in German.
+<%= packageManager %> run start <%= cliSeparator %>--language=de
+```
+
+### `test`
+
+Allows executing unit tests for the package, specified in the `tests/` directory. The command accepts the following modifiers:
+
+* `--coverage` &ndash; to create the code coverage report,
+* `--watch` &ndash; to observe the source files (the command does not end after executing tests),
+* `--source-map` &ndash; to generate source maps of sources,
+* `--verbose` &ndash; to print additional webpack logs.
+
+Examples:
+
+```bash
+# Execute tests.
+<%= packageManager %> run test
+
+# Generate code coverage report after each change in the sources.
+<%= packageManager %> run test <%= cliSeparator %>--coverage --test
+```
+
+### `lint`
+
+Runs ESLint, which analyzes the code (all `*.<%= programmingLanguage %>` files) to quickly find problems.
+
+Examples:
+
+```bash
+# Execute eslint.
+<%= packageManager %> run lint
+```
+
+### `stylelint`
+
+Similar to the `lint` task, stylelint analyzes the CSS code (`*.css` files in the `theme/` directory) in the package.
+
+Examples:
+
+```bash
+# Execute stylelint.
+<%= packageManager %> run stylelint
+```
+
+### `build:dist`
+
+Creates npm and browser builds of your plugin. These builds can be added to the editor by following the [Configuring CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/configuration.html) guide.
+
+Examples:
+
+```bash
+# Builds the `npm` and browser files thats are ready to publish.
+npm run build:dist
+```
+
+### `translations:collect`
+
+Collects translation messages (arguments of the `t()` function) and context files, then validates whether the provided values do not interfere with the values specified in the `@ckeditor/ckeditor5-core` package.
+
+The task may end with an error if one of the following conditions is met:
+
+* Found the `Unused context` error &ndash; entries specified in the `lang/contexts.json` file are not used in source files. They should be removed.
+* Found the `Context is duplicated for the id` error &ndash; some of the entries are duplicated. Consider removing them from the `lang/contexts.json` file, or rewrite them.
+* Found the `Context for the message id is missing` error &ndash; entries specified in source files are not described in the `lang/contexts.json` file. They should be added.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:collect
+```
+
+### `translations:download`
+
+Download translations from the Transifex server. Depending on users' activity in the project, it creates translations files used for building the editor.
+
+The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
+
+To avoid passing the `--transifex` option every time when calls the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:download <%= cliSeparator %>--transifex [API URL]
+```
+
+### `translations:upload`
+
+Uploads translation messages onto the Transifex server. It allows for the creation of translations into other languages by users using the Transifex platform.
+
+The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
+
+To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:upload <%= cliSeparator %>--transifex [API URL]
+```
+
+## License
+
+The `<%= packageName %>` package is available under [MIT license](https://opensource.org/licenses/MIT).
+
+However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and it can be changed.

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -133,7 +133,7 @@ Examples:
 
 ### `translations:upload`
 
-Uploads translation messages onto the Transifex server. It allows for the creation of translations into other languages by users using the Transifex platform.
+Uploads translation messages onto the Transifex server. It allows users to create translations into other languages using the Transifex platform.
 
 The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -149,4 +149,4 @@ Examples:
 
 The `<%= packageName %>` package is available under [MIT license](https://opensource.org/licenses/MIT).
 
-However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and it can be changed.
+However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and can be changed.

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -92,7 +92,7 @@ Examples:
 
 ### `build:dist`
 
-Creates npm and browser builds of your plugin. These builds can be added to the editor by following the [Configuring CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/configuration.html) guide.
+Creates npm and browser builds of your plugin. These builds can be added to the editor following the [Configuring CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/configuration.html) guide.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/js/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/js/README.md
@@ -137,7 +137,7 @@ Uploads translation messages onto the Transifex server. It allows users to creat
 
 The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
+To avoid passing the `--transifex` option whenever you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
@@ -22,11 +22,11 @@ This package was created by the [ckeditor5-package-generator](https://www.npmjs.
 
 ## Developing the package
 
-To read about the CKEditor 5 framework, visit the [CKEditor5 documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
+To read about the CKEditor 5 Framework, visit the [CKEditor 5 Framework documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
 
 ## Available scripts
 
-Npm scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
 
 All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
 
@@ -34,7 +34,7 @@ The following scripts are available in the package.
 
 ### `start`
 
-Starts a HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
+Starts an HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
 
 When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
 
@@ -107,7 +107,7 @@ npm run build:dist
 
 ### `dll:build`
 
-Creates a DLL-compatible package build which can be loaded into an editor using [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
+Creates a DLL-compatible package build that can be loaded into an editor using [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
 
 Examples:
 
@@ -148,11 +148,11 @@ Examples:
 
 ### `translations:download`
 
-Download translations from the Transifex server. Depending on users' activity in the project, it creates translations files used for building the editor.
+Download translations from the Transifex server. Depending on users' activity in the project, it creates translation files used for building the editor.
 
 The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when calls the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
@@ -162,7 +162,7 @@ Examples:
 
 ### `translations:upload`
 
-Uploads translation messages onto the Transifex server. It allows for the creation of translations into other languages by users using the Transifex platform.
+Uploads translation messages onto the Transifex server. It allows users to create translations into other languages using the Transifex platform.
 
 The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
@@ -182,4 +182,4 @@ These scripts compile TypeScript and remove the compiled files. They are used in
 
 The `<%= packageName %>` package is available under [MIT license](https://opensource.org/licenses/MIT).
 
-However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and it can be changed.
+However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and can be changed.

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
@@ -26,7 +26,7 @@ To read about the CKEditor 5 Framework, visit the [CKEditor 5 Framework document
 
 ## Available scripts
 
-NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with people contributing to the project. It ensures developers use the same command with the same options (flags).
 
 All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
@@ -152,7 +152,7 @@ Download translations from the Transifex server. Depending on users' activity in
 
 The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+To avoid passing the `--transifex` option whenever you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
@@ -36,7 +36,7 @@ The following scripts are available in the package.
 
 Starts an HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
 
-When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
+When the server starts, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
 
 You can also define the language that will translate the created editor by specifying the `--language [LANG]` option. It defaults to `'en'`.
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
@@ -1,0 +1,185 @@
+<%= packageName %>
+<% print( '='.repeat( packageName.length ) ) %>
+
+This package was created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package.
+
+## Table of contents
+
+* [Developing the package](#developing-the-package)
+* [Available scripts](#available-scripts)
+  * [`start`](#start)
+  * [`test`](#test)
+  * [`lint`](#lint)
+  * [`stylelint`](#stylelint)
+  * [`build:dist`](#builddist)
+  * [`dll:build`](#dllbuild)
+  * [`dll:serve`](#dllserve)
+  * [`translations:collect`](#translationscollect)
+  * [`translations:download`](#translationsdownload)
+  * [`translations:upload`](#translationsupload)
+  * [`ts:build` and `ts:clear`](#tsbuild-and-tsclear)
+* [License](#license)
+
+## Developing the package
+
+To read about the CKEditor 5 framework, visit the [CKEditor5 documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
+
+## Available scripts
+
+Npm scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+
+All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
+
+The following scripts are available in the package.
+
+### `start`
+
+Starts a HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
+
+When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
+
+You can also define the language that will translate the created editor by specifying the `--language [LANG]` option. It defaults to `'en'`.
+
+Examples:
+
+```bash
+# Starts the server and open the browser.
+<%= packageManager %> run start
+
+# Disable auto-opening the browser.
+<%= packageManager %> run start <%= cliSeparator %>--no-open
+
+# Create the editor with the interface in German.
+<%= packageManager %> run start <%= cliSeparator %>--language=de
+```
+
+### `test`
+
+Allows executing unit tests for the package, specified in the `tests/` directory. The command accepts the following modifiers:
+
+* `--coverage` &ndash; to create the code coverage report,
+* `--watch` &ndash; to observe the source files (the command does not end after executing tests),
+* `--source-map` &ndash; to generate source maps of sources,
+* `--verbose` &ndash; to print additional webpack logs.
+
+Examples:
+
+```bash
+# Execute tests.
+<%= packageManager %> run test
+
+# Generate code coverage report after each change in the sources.
+<%= packageManager %> run test <%= cliSeparator %>--coverage --test
+```
+
+### `lint`
+
+Runs ESLint, which analyzes the code (all `*.<%= programmingLanguage %>` files) to quickly find problems.
+
+Examples:
+
+```bash
+# Execute eslint.
+<%= packageManager %> run lint
+```
+
+### `stylelint`
+
+Similar to the `lint` task, stylelint analyzes the CSS code (`*.css` files in the `theme/` directory) in the package.
+
+Examples:
+
+```bash
+# Execute stylelint.
+<%= packageManager %> run stylelint
+```
+
+### `build:dist`
+
+Creates npm and browser builds of your plugin. These builds can be added to the editor by following the [Configuring CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/configuration.html) guide.
+
+Examples:
+
+```bash
+# Builds the `npm` and browser files thats are ready to publish.
+npm run build:dist
+```
+
+### `dll:build`
+
+Creates a DLL-compatible package build which can be loaded into an editor using [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
+
+Examples:
+
+```bash
+# Build the DLL file that is ready to publish.
+<%= packageManager %> run dll:build
+
+# Build the DLL file and listen to changes in its sources.
+<%= packageManager %> run dll:build <%= cliSeparator %>--watch
+```
+
+### `dll:serve`
+
+Creates a simple HTTP server (without the live-reload mechanism) that allows verifying whether the DLL build of the package is compatible with the CKEditor 5 [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
+
+Examples:
+
+```bash
+# Starts the HTTP server and opens the browser.
+<%= packageManager %> run dll:serve
+```
+
+### `translations:collect`
+
+Collects translation messages (arguments of the `t()` function) and context files, then validates whether the provided values do not interfere with the values specified in the `@ckeditor/ckeditor5-core` package.
+
+The task may end with an error if one of the following conditions is met:
+
+* Found the `Unused context` error &ndash; entries specified in the `lang/contexts.json` file are not used in source files. They should be removed.
+* Found the `Context is duplicated for the id` error &ndash; some of the entries are duplicated. Consider removing them from the `lang/contexts.json` file, or rewrite them.
+* Found the `Context for the message id is missing` error &ndash; entries specified in source files are not described in the `lang/contexts.json` file. They should be added.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:collect
+```
+
+### `translations:download`
+
+Download translations from the Transifex server. Depending on users' activity in the project, it creates translations files used for building the editor.
+
+The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
+
+To avoid passing the `--transifex` option every time when calls the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:download <%= cliSeparator %>--transifex [API URL]
+```
+
+### `translations:upload`
+
+Uploads translation messages onto the Transifex server. It allows for the creation of translations into other languages by users using the Transifex platform.
+
+The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
+
+To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
+
+Examples:
+
+```bash
+<%= packageManager %> run translations:upload <%= cliSeparator %>--transifex [API URL]
+```
+
+### `ts:build` and `ts:clear`
+
+These scripts compile TypeScript and remove the compiled files. They are used in the aforementioned life cycle scripts, and there is no need to call them manually.
+
+## License
+
+The `<%= packageName %>` package is available under [MIT license](https://opensource.org/licenses/MIT).
+
+However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and it can be changed.

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/README.md
@@ -166,7 +166,7 @@ Uploads translation messages onto the Transifex server. It allows users to creat
 
 The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
+To avoid passing the `--transifex` option whenever you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/README.md
@@ -11,11 +11,11 @@ This package was created by the [ckeditor5-package-generator](https://www.npmjs.
   * [`test`](#test)
   * [`lint`](#lint)
   * [`stylelint`](#stylelint)
-  * [`dll:build`](#dllbuild)
-  * [`dll:serve`](#dllserve)
+  * [`build:dist`](#builddist)
   * [`translations:collect`](#translationscollect)
   * [`translations:download`](#translationsdownload)
   * [`translations:upload`](#translationsupload)
+  * [`ts:build` and `ts:clear`](#tsbuild-and-tsclear)
 * [License](#license)
 
 ## Developing the package
@@ -92,29 +92,15 @@ Examples:
 <%= packageManager %> run stylelint
 ```
 
-### `dll:build`
+### `build:dist`
 
-Creates a DLL-compatible package build which can be loaded into an editor using [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
-
-Examples:
-
-```bash
-# Build the DLL file that is ready to publish.
-<%= packageManager %> run dll:build
-
-# Build the DLL file and listen to changes in its sources.
-<%= packageManager %> run dll:build <%= cliSeparator %>--watch
-```
-
-### `dll:serve`
-
-Creates a simple HTTP server (without the live-reload mechanism) that allows verifying whether the DLL build of the package is compatible with the CKEditor 5 [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/dll-builds.html).
+Creates npm and browser builds of your plugin. These builds can be added to the editor by following the [Configuring CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/configuration.html) guide.
 
 Examples:
 
 ```bash
-# Starts the HTTP server and opens the browser.
-<%= packageManager %> run dll:serve
+# Builds the `npm` and browser files thats are ready to publish.
+npm run build:dist
 ```
 
 ### `translations:collect`
@@ -160,6 +146,10 @@ Examples:
 ```bash
 <%= packageManager %> run translations:upload <%= cliSeparator %>--transifex [API URL]
 ```
+
+### `ts:build` and `ts:clear`
+
+These scripts compile TypeScript and remove the compiled files. They are used in the aforementioned life cycle scripts, and there is no need to call them manually.
 
 ## License
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/README.md
@@ -139,7 +139,7 @@ Uploads translation messages onto the Transifex server. It allows users to creat
 
 The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
+To avoid passing the `--transifex` option whenever you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:upload` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/README.md
@@ -34,7 +34,7 @@ The following scripts are available in the package.
 
 Starts an HTTP server with the live-reload mechanism that allows previewing and testing of plugins available in the package.
 
-When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
+When the server starts, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
 
 You can also define the language that will translate the created editor by specifying the `--language [LANG]` option. It defaults to `'en'`.
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/README.md
@@ -135,7 +135,7 @@ Examples:
 
 ### `translations:upload`
 
-Uploads translation messages onto the Transifex server. It allows for the creation of translations into other languages by users using the Transifex platform.
+Uploads translation messages onto the Transifex server. It allows users to create translations into other languages using the Transifex platform.
 
 The task requires passing the URL to the Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/README.md
@@ -20,11 +20,11 @@ This package was created by the [ckeditor5-package-generator](https://www.npmjs.
 
 ## Developing the package
 
-To read about the CKEditor 5 framework, visit the [CKEditor5 documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
+To read about the CKEditor 5 Framework, visit the [CKEditor 5 Framework documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html).
 
 ## Available scripts
 
-Npm scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
 
 All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
 
@@ -32,7 +32,7 @@ The following scripts are available in the package.
 
 ### `start`
 
-Starts a HTTP server with the live-reload mechanism that allows previewing and testing plugins available in the package.
+Starts an HTTP server with the live-reload mechanism that allows previewing and testing of plugins available in the package.
 
 When the server has been started, the default browser will open the developer sample. This can be disabled by passing the `--no-open` option to that command.
 
@@ -121,7 +121,7 @@ Examples:
 
 ### `translations:download`
 
-Download translations from the Transifex server. Depending on users' activity in the project, it creates translations files used for building the editor.
+Download translations from the Transifex server. Depending on users' activity in the project, it creates translation files used for building the editor.
 
 The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/README.md
@@ -125,7 +125,7 @@ Download translations from the Transifex server. Depending on users' activity in
 
 The task requires passing the URL to Transifex API. Usually, it matches the following format: `https://www.transifex.com/api/2/project/[PROJECT_SLUG]`.
 
-To avoid passing the `--transifex` option every time when calls the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
+To avoid passing the `--transifex` option whenever you call the command, you can store it in `package.json`, next to the `ckeditor5-package-tools translations:download` command.
 
 Examples:
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/README.md
@@ -24,7 +24,7 @@ To read about the CKEditor 5 Framework, visit the [CKEditor 5 Framework document
 
 ## Available scripts
 
-NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with other people contributing to the project. It ensures that developers use the same command with the same options (flags).
+NPM scripts are a convenient way to provide commands in a project. They are defined in the `package.json` file and shared with people contributing to the project. It ensures developers use the same command with the same options (flags).
 
 All the scripts can be executed by running `<%= packageManager %> run <script>`. Pre and post commands with matching names will be run for those as well.
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/README.md
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/README.md
@@ -155,4 +155,4 @@ These scripts compile TypeScript and remove the compiled files. They are used in
 
 The `<%= packageName %>` package is available under [MIT license](https://opensource.org/licenses/MIT).
 
-However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and it can be changed.
+However, it is the default license of packages created by the [ckeditor5-package-generator](https://www.npmjs.com/package/ckeditor5-package-generator) package and can be changed.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (generator): Each package template should have own `README.md` based on what commands can be execute in it. Closes https://github.com/ckeditor/ckeditor5-package-generator/issues/174.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
