### PR TITLE
Lock to the last compatible version of the `@ckeditor/ckeditor5-dev-build-tools` package

### DIFF
--- a/packages/ckeditor5-package-generator/lib/utils/get-dependencies-versions.js
+++ b/packages/ckeditor5-package-generator/lib/utils/get-dependencies-versions.js
@@ -30,11 +30,17 @@ const getPackageVersion = require( './get-package-version' );
 module.exports = function getDependenciesVersions( logger, dev ) {
 	logger.process( 'Collecting the latest CKEditor 5 packages versions...' );
 
+	// Due to the release of breaking changes in the `@ckeditor/ckeditor5-dev-*` packages, package generator must lock
+	// a version of the `@ckeditor/ckeditor5-dev-build-tools` package to the last compatible version: ^43.0.0.
+	// Package generator will be able to use latest stable version of the `@ckeditor/ckeditor5-dev-build-tools` when
+	// all blockers specified in https://github.com/ckeditor/ckeditor5-package-generator/issues/192 are resolved.
+	const ckeditor5DevBuildToolsVersion = '43.0.0';
+
 	return {
 		ckeditor5: getPackageVersion( 'ckeditor5' ),
 		ckeditor5PremiumFeatures: getPackageVersion( 'ckeditor5-premium-features' ),
 		ckeditor5Inspector: getPackageVersion( '@ckeditor/ckeditor5-inspector' ),
-		ckeditor5DevBuildTools: getPackageVersion( '@ckeditor/ckeditor5-dev-build-tools' ),
+		ckeditor5DevBuildTools: ckeditor5DevBuildToolsVersion,
 		eslintConfigCkeditor5: getPackageVersion( 'eslint-config-ckeditor5' ),
 		stylelintConfigCkeditor5: getPackageVersion( 'stylelint-config-ckeditor5' ),
 		packageTools: dev ?

--- a/packages/ckeditor5-package-generator/tests/utils/get-dependencies-versions.js
+++ b/packages/ckeditor5-package-generator/tests/utils/get-dependencies-versions.js
@@ -31,6 +31,7 @@ describe( 'lib/utils/get-dependencies-versions', () => {
 		stubs.getPackageVersion.withArgs( 'ckeditor5' ).returns( '30.0.0' );
 		stubs.getPackageVersion.withArgs( '@ckeditor/ckeditor5-package-tools' ).returns( '1.0.0' );
 		stubs.getPackageVersion.withArgs( '@ckeditor/ckeditor5-inspector' ).returns( '4.0.0' );
+		stubs.getPackageVersion.withArgs( '@ckeditor/ckeditor5-dev-build-tools' ).returns( '7.0.0' );
 		stubs.getPackageVersion.withArgs( 'eslint-config-ckeditor5' ).returns( '5.0.0' );
 		stubs.getPackageVersion.withArgs( 'stylelint-config-ckeditor5' ).returns( '3.0.0' );
 
@@ -58,7 +59,12 @@ describe( 'lib/utils/get-dependencies-versions', () => {
 		expect( returnedValue.ckeditor5 ).to.equal( '30.0.0' );
 	} );
 
-	it( 'returns an object with a version of the "eslint-config-ckeditor5', () => {
+	it( 'returns an object with a last compatible version of the "@ckeditor/ckeditor5-dev-build-tools" instead of the latest one', () => {
+		const returnedValue = getDependenciesVersions( stubs.logger, false );
+		expect( returnedValue.ckeditor5DevBuildTools ).to.equal( '43.0.0' );
+	} );
+
+	it( 'returns an object with a version of the "eslint-config-ckeditor5"', () => {
 		const returnedValue = getDependenciesVersions( stubs.logger, false );
 		expect( returnedValue.eslintConfigCkeditor5 ).to.equal( '5.0.0' );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (generator): Lock to the last compatible version of the `@ckeditor/ckeditor5-dev-build-tools` package due to the upcoming release of breaking changes in the `@ckeditor/ckeditor5-dev-*` packages. Closes #191.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
