### PR TITLE
Aligned the UI component name to naming convention in CKEditor 5

### DIFF
--- a/packages/ckeditor5-package-generator/lib/templates/common/ckeditor5-metadata.json
+++ b/packages/ckeditor5-package-generator/lib/templates/common/ckeditor5-metadata.json
@@ -7,7 +7,7 @@
       "path": "src/<%= formattedNames.plugin.lowerCaseMerged %>.<%= programmingLanguage %>",
       "uiComponents": [
         {
-          "name": "<%= formattedNames.plugin.camelCase %>Button",
+          "name": "<%= formattedNames.plugin.camelCase %>",
           "type": "Button",
           "iconPath": "theme/icons/ckeditor.svg"
         }

--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/sample/ckeditor.js.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/sample/ckeditor.js.txt
@@ -49,7 +49,7 @@ ClassicEditor
 			Base64UploadAdapter
 		],
 		toolbar: [
-			'<%= formattedNames.plugin.camelCase %>Button',
+			'<%= formattedNames.plugin.camelCase %>',
 			'|',
 			'heading',
 			'|',

--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/sample/dll.html.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/sample/dll.html.txt
@@ -111,7 +111,7 @@
 				CKEditor5.upload.Base64UploadAdapter
 			],
 			toolbar: [
-				'<%= formattedNames.plugin.camelCase %>Button',
+				'<%= formattedNames.plugin.camelCase %>',
 				'|',
 				'heading',
 				'|',

--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/src/_PLACEHOLDER_.js.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/src/_PLACEHOLDER_.js.txt
@@ -13,8 +13,8 @@ export default class <%= formattedNames.plugin.pascalCase %> extends Plugin {
 		const t = editor.t;
 		const model = editor.model;
 
-		// Add the "<%= formattedNames.plugin.camelCase %>Button" to feature components.
-		editor.ui.componentFactory.add( '<%= formattedNames.plugin.camelCase %>Button', locale => {
+		// Register the "<%= formattedNames.plugin.camelCase %>" button, so it can be displayed in the toolbar.
+		editor.ui.componentFactory.add( '<%= formattedNames.plugin.camelCase %>', locale => {
 			const view = new ButtonView( locale );
 
 			view.set( {

--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/tests/_PLACEHOLDER_.js.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/tests/_PLACEHOLDER_.js.txt
@@ -28,7 +28,7 @@ describe( '<%= formattedNames.plugin.pascalCase %>', () => {
 					<%= formattedNames.plugin.pascalCase %>
 				],
 				toolbar: [
-					'<%= formattedNames.plugin.camelCase %>Button'
+					'<%= formattedNames.plugin.camelCase %>'
 				]
 			} );
 		} );
@@ -45,11 +45,11 @@ describe( '<%= formattedNames.plugin.pascalCase %>', () => {
 		} );
 
 		it( 'should add an icon to the toolbar', () => {
-			expect( editor.ui.componentFactory.has( '<%= formattedNames.plugin.camelCase %>Button' ) ).to.equal( true );
+			expect( editor.ui.componentFactory.has( '<%= formattedNames.plugin.camelCase %>' ) ).to.equal( true );
 		} );
 
 		it( 'should add a text into the editor after clicking the icon', () => {
-			const icon = editor.ui.componentFactory.create( '<%= formattedNames.plugin.camelCase %>Button' );
+			const icon = editor.ui.componentFactory.create( '<%= formattedNames.plugin.camelCase %>' );
 
 			expect( editor.getData() ).to.equal( '' );
 

--- a/packages/ckeditor5-package-generator/lib/templates/js/sample/ckeditor.js.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/js/sample/ckeditor.js.txt
@@ -62,7 +62,7 @@ ClassicEditor
 			'undo',
 			'redo',
 			'|',
-			'<%= formattedNames.plugin.camelCase %>Button',
+			'<%= formattedNames.plugin.camelCase %>',
 			'|',
 			'heading',
 			'|',

--- a/packages/ckeditor5-package-generator/lib/templates/js/src/_PLACEHOLDER_.js.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/js/src/_PLACEHOLDER_.js.txt
@@ -12,8 +12,8 @@ export default class <%= formattedNames.plugin.pascalCase %> extends Plugin {
 		const t = editor.t;
 		const model = editor.model;
 
-		// Add the "<%= formattedNames.plugin.camelCase %>Button" to feature components.
-		editor.ui.componentFactory.add( '<%= formattedNames.plugin.camelCase %>Button', locale => {
+		// Register the "<%= formattedNames.plugin.camelCase %>" button, so it can be displayed in the toolbar.
+		editor.ui.componentFactory.add( '<%= formattedNames.plugin.camelCase %>', locale => {
 			const view = new ButtonView( locale );
 
 			view.set( {

--- a/packages/ckeditor5-package-generator/lib/templates/js/tests/_PLACEHOLDER_.js.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/js/tests/_PLACEHOLDER_.js.txt
@@ -25,7 +25,7 @@ describe( '<%= formattedNames.plugin.pascalCase %>', () => {
 					<%= formattedNames.plugin.pascalCase %>
 				],
 				toolbar: [
-					'<%= formattedNames.plugin.camelCase %>Button'
+					'<%= formattedNames.plugin.camelCase %>'
 				]
 			} );
 		} );
@@ -42,11 +42,11 @@ describe( '<%= formattedNames.plugin.pascalCase %>', () => {
 		} );
 
 		it( 'should add an icon to the toolbar', () => {
-			expect( editor.ui.componentFactory.has( '<%= formattedNames.plugin.camelCase %>Button' ) ).to.equal( true );
+			expect( editor.ui.componentFactory.has( '<%= formattedNames.plugin.camelCase %>' ) ).to.equal( true );
 		} );
 
 		it( 'should add a text into the editor after clicking the icon', () => {
-			const icon = editor.ui.componentFactory.create( '<%= formattedNames.plugin.camelCase %>Button' );
+			const icon = editor.ui.componentFactory.create( '<%= formattedNames.plugin.camelCase %>' );
 
 			expect( editor.getData() ).to.equal( '' );
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/sample/ckeditor.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/sample/ckeditor.ts.txt
@@ -53,7 +53,7 @@ ClassicEditor
 			Base64UploadAdapter
 		],
 		toolbar: [
-			'<%= formattedNames.plugin.camelCase %>Button',
+			'<%= formattedNames.plugin.camelCase %>',
 			'|',
 			'heading',
 			'|',

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/sample/dll.html.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/sample/dll.html.txt
@@ -122,7 +122,7 @@
 				CKEditor5.upload.Base64UploadAdapter
 			],
 			toolbar: [
-				'<%= formattedNames.plugin.camelCase %>Button',
+				'<%= formattedNames.plugin.camelCase %>',
 				'|',
 				'heading',
 				'|',

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/src/_PLACEHOLDER_.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/src/_PLACEHOLDER_.ts.txt
@@ -13,8 +13,8 @@ export default class <%= formattedNames.plugin.pascalCase %> extends Plugin {
 		const t = editor.t;
 		const model = editor.model;
 
-		// Add the "<%= formattedNames.plugin.camelCase %>Button" to feature components.
-		editor.ui.componentFactory.add( '<%= formattedNames.plugin.camelCase %>Button', locale => {
+		// Register the "<%= formattedNames.plugin.camelCase %>" button, so it can be displayed in the toolbar.
+		editor.ui.componentFactory.add( '<%= formattedNames.plugin.camelCase %>', locale => {
 			const view = new ButtonView( locale );
 
 			view.set( {

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/tests/_PLACEHOLDER_.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/tests/_PLACEHOLDER_.ts.txt
@@ -26,7 +26,7 @@ describe( '<%= formattedNames.plugin.pascalCase %>', () => {
 					<%= formattedNames.plugin.pascalCase %>
 				],
 				toolbar: [
-					'<%= formattedNames.plugin.camelCase %>Button'
+					'<%= formattedNames.plugin.camelCase %>'
 				]
 			} );
 		} );
@@ -43,11 +43,11 @@ describe( '<%= formattedNames.plugin.pascalCase %>', () => {
 		} );
 
 		it( 'should add an icon to the toolbar', () => {
-			expect( editor.ui.componentFactory.has( '<%= formattedNames.plugin.camelCase %>Button' ) ).to.equal( true );
+			expect( editor.ui.componentFactory.has( '<%= formattedNames.plugin.camelCase %>' ) ).to.equal( true );
 		} );
 
 		it( 'should add a text into the editor after clicking the icon', () => {
-			const icon = editor.ui.componentFactory.create( '<%= formattedNames.plugin.camelCase %>Button' );
+			const icon = editor.ui.componentFactory.create( '<%= formattedNames.plugin.camelCase %>' );
 
 			expect( editor.getData() ).to.equal( '' );
 

--- a/packages/ckeditor5-package-generator/lib/templates/ts/sample/ckeditor.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/sample/ckeditor.ts.txt
@@ -66,7 +66,7 @@ ClassicEditor
 			'undo',
 			'redo',
 			'|',
-			'<%= formattedNames.plugin.camelCase %>Button',
+			'<%= formattedNames.plugin.camelCase %>',
 			'|',
 			'heading',
 			'|',

--- a/packages/ckeditor5-package-generator/lib/templates/ts/sample/dll.html.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/sample/dll.html.txt
@@ -121,7 +121,7 @@
 				CKEditor5.upload.Base64UploadAdapter
 			],
 			toolbar: [
-				'<%= formattedNames.plugin.camelCase %>Button',
+				'<%= formattedNames.plugin.camelCase %>',
 				'|',
 				'heading',
 				'|',

--- a/packages/ckeditor5-package-generator/lib/templates/ts/src/_PLACEHOLDER_.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/src/_PLACEHOLDER_.ts.txt
@@ -12,8 +12,8 @@ export default class <%= formattedNames.plugin.pascalCase %> extends Plugin {
 		const t = editor.t;
 		const model = editor.model;
 
-		// Add the "<%= formattedNames.plugin.camelCase %>Button" to feature components.
-		editor.ui.componentFactory.add( '<%= formattedNames.plugin.camelCase %>Button', locale => {
+		// Register the "<%= formattedNames.plugin.camelCase %>" button, so it can be displayed in the toolbar.
+		editor.ui.componentFactory.add( '<%= formattedNames.plugin.camelCase %>', locale => {
 			const view = new ButtonView( locale );
 
 			view.set( {

--- a/packages/ckeditor5-package-generator/lib/templates/ts/tests/_PLACEHOLDER_.ts.txt
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/tests/_PLACEHOLDER_.ts.txt
@@ -23,7 +23,7 @@ describe( '<%= formattedNames.plugin.pascalCase %>', () => {
 					<%= formattedNames.plugin.pascalCase %>
 				],
 				toolbar: [
-					'<%= formattedNames.plugin.camelCase %>Button'
+					'<%= formattedNames.plugin.camelCase %>'
 				]
 			} );
 		} );
@@ -40,11 +40,11 @@ describe( '<%= formattedNames.plugin.pascalCase %>', () => {
 		} );
 
 		it( 'should add an icon to the toolbar', () => {
-			expect( editor.ui.componentFactory.has( '<%= formattedNames.plugin.camelCase %>Button' ) ).to.equal( true );
+			expect( editor.ui.componentFactory.has( '<%= formattedNames.plugin.camelCase %>' ) ).to.equal( true );
 		} );
 
 		it( 'should add a text into the editor after clicking the icon', () => {
-			const icon = editor.ui.componentFactory.create( '<%= formattedNames.plugin.camelCase %>Button' );
+			const icon = editor.ui.componentFactory.create( '<%= formattedNames.plugin.camelCase %>' );
 
 			expect( editor.getData() ).to.equal( '' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (generator): Aligned the UI component name from the generated package to naming convention in CKEditor 5. Closes #209.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
