### PR TITLE
Display suggested global name for UMD build from the plugin name

### DIFF
--- a/packages/ckeditor5-package-generator/lib/index.js
+++ b/packages/ckeditor5-package-generator/lib/index.js
@@ -35,7 +35,10 @@ export default async function init( packageName, options ) {
 	const packageManager = await choosePackageManager( useNpm, useYarn );
 	const programmingLanguage = await chooseProgrammingLanguage( logger, lang );
 	const installationMethodOfPackage = await chooseInstallationMethods( logger, installationMethods );
-	const validatedGlobalName = await setGlobalName( logger, globalName );
+
+	const defaultGlobalName = 'CK' + formattedNames.plugin.pascalCase;
+	const validatedGlobalName = await setGlobalName( logger, globalName, defaultGlobalName );
+
 	const packageVersions = getDependenciesVersions( logger, dev );
 
 	copyFiles( logger, {

--- a/packages/ckeditor5-package-generator/lib/utils/set-global-name.js
+++ b/packages/ckeditor5-package-generator/lib/utils/set-global-name.js
@@ -13,9 +13,10 @@ import validateGlobalName from './validate-global-name.js';
  *
  * @param {Logger} logger
  * @param {String} globalName
+ * @param {String} defaultGlobalName
  * @returns {Promise.<String>}
  */
-export default async function setGlobalName( logger, globalName ) {
+export default async function setGlobalName( logger, globalName, defaultGlobalName ) {
 	if ( globalName ) {
 		if ( validateGlobalName( logger, globalName ) ) {
 			return globalName;
@@ -28,10 +29,11 @@ export default async function setGlobalName( logger, globalName ) {
 
 	const globalNameFromInput = await inquirer.prompt( {
 		required: true,
-		message: 'Enter the global name for plugin for UMD build',
+		message: 'Enter the global name for UMD build:',
 		type: 'input',
 		name: 'globalName',
-		validate: validateGlobalName.bind( this, logger )
+		validate: validateGlobalName.bind( this, logger ),
+		default: defaultGlobalName
 	} );
 
 	return globalNameFromInput.globalName;

--- a/packages/ckeditor5-package-generator/tests/index.js
+++ b/packages/ckeditor5-package-generator/tests/index.js
@@ -199,7 +199,7 @@ describe( 'lib/index', () => {
 		await index( packageName, options );
 
 		expect( setGlobalName ).toHaveBeenCalledTimes( 1 );
-		expect( setGlobalName ).toHaveBeenCalledWith( expect.any( Logger ), 'GLOBAL' );
+		expect( setGlobalName ).toHaveBeenCalledWith( expect.any( Logger ), 'GLOBAL', 'CKBarBaz' );
 	} );
 
 	it( 'gets the versions of the dependencies', async () => {

--- a/packages/ckeditor5-package-generator/tests/utils/set-global-name.js
+++ b/packages/ckeditor5-package-generator/tests/utils/set-global-name.js
@@ -30,15 +30,16 @@ describe( 'lib/utils/set-global-name', () => {
 	} );
 
 	it( 'calls prompt() with correct arguments', async () => {
-		await setGlobalName( stubs.logger );
+		await setGlobalName( stubs.logger, '', 'CKCustomPlugin' );
 
 		expect( inquirer.prompt ).toHaveBeenCalledTimes( 1 );
 		expect( inquirer.prompt ).toHaveBeenCalledWith( {
 			required: true,
-			message: 'Enter the global name for plugin for UMD build',
+			message: 'Enter the global name for UMD build:',
 			type: 'input',
 			name: 'globalName',
-			validate: expect.any( Function )
+			validate: expect.any( Function ),
+			default: 'CKCustomPlugin'
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (generator): The package generator prompt displays the suggested name for the UMD build. The name is created from the plugin name and prefixed with the `CK`. Closes #207.

---

### Additional information

Package generator suggests now the global name for the UMD build. Assuming that the name of the package being created is `@test-scope/ckeditor5-custom-plugin`, the package generator suggests `CKCustomPlugin` as the default UMD name:

```
? Enter the global name for UMD build: (CKCustomPlugin)
```

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
