### PR TITLE
Bump Stylelint to v16.x

### DIFF
--- a/packages/ckeditor5-package-generator/lib/templates/js-legacy/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/js-legacy/package.json
@@ -45,7 +45,7 @@
     "http-server": "^14.1.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.6",
-    "stylelint": "^13.13.1",
+    "stylelint": "^16.0.0",
     "stylelint-config-ckeditor5": "^<%= packageVersions.stylelintConfigCkeditor5 %>",
     "vite-plugin-svgo": "~1.4.0",
     "vitest": "^2.0.5",

--- a/packages/ckeditor5-package-generator/lib/templates/js/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/js/package.json
@@ -38,7 +38,7 @@
     "http-server": "^14.1.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.6",
-    "stylelint": "^13.13.1",
+    "stylelint": "^16.0.0",
     "stylelint-config-ckeditor5": "^<%= packageVersions.stylelintConfigCkeditor5 %>",
     "vite-plugin-svgo": "~1.4.0",
     "vitest": "^2.0.5",

--- a/packages/ckeditor5-package-generator/lib/templates/ts-legacy/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/ts-legacy/package.json
@@ -53,7 +53,7 @@
     "http-server": "^14.1.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.6",
-    "stylelint": "^13.13.1",
+    "stylelint": "^16.0.0",
     "stylelint-config-ckeditor5": "^<%= packageVersions.stylelintConfigCkeditor5 %>",
     "ts-node": "^10.9.1",
     "typescript": "5.0.4",

--- a/packages/ckeditor5-package-generator/lib/templates/ts/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/package.json
@@ -43,7 +43,7 @@
     "http-server": "^14.1.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.6",
-    "stylelint": "^13.13.1",
+    "stylelint": "^16.0.0",
     "stylelint-config-ckeditor5": "^<%= packageVersions.stylelintConfigCkeditor5 %>",
     "ts-node": "^10.9.1",
     "typescript": "5.0.4",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (generator): The Stylelint version in the generated packages has been bumped to v16.x.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*

### Supported scopes

* `generator` → https://www.npmjs.com/package/ckeditor5-package-generator
* `*` → https://www.npmjs.com/package/@ckeditor/ckeditor5-package-*
