### PR TITLE
Verify build on CI with a timeout

### DIFF
--- a/scripts/ci/verify-build.js
+++ b/scripts/ci/verify-build.js
@@ -20,7 +20,7 @@ const __dirname = path.dirname( __filename );
 const REPOSITORY_DIRECTORY = path.join( __dirname, '..', '..' );
 const NEW_PACKAGE_DIRECTORY = path.join( REPOSITORY_DIRECTORY, '..', 'ckeditor5-test-package' );
 
-const VERIFICATION_TIMEOUT = 5 * 60 * 1000;
+const VERIFICATION_TIMEOUT = 3 * 60 * 1000;
 
 // A flag that determines whether any of the executed commands resulted in an error.
 let foundError = false;


### PR DESCRIPTION

<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

This PR introduces an improvement in our CI workflow to ensure that waiting for a build verification on CI will take no longer than the specified timeout.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #253

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
