### PR TITLE
Replaced `path` package with `upath` to ensure that all paths are normalized

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,8 +149,14 @@ jobs:
                     circleci-agent step halt
                   fi
             - run:
-                name: Upload code coverage
-                command: cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+                name: Upload code coverage (non-fatal)
+                command: |
+                  #!/bin/bash
+
+                  set -eo pipefail
+
+                  cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js \
+                    || echo "Coveralls upload failed (e.g., 504). Continuing without failing CI."
 
   package_js_npm_both_install_methods:
     docker:

--- a/packages/ckeditor5-package-generator/bin/index.js
+++ b/packages/ckeditor5-package-generator/bin/index.js
@@ -6,11 +6,11 @@
  */
 
 import fs from 'fs-extra';
-import path from 'path';
+import upath from 'upath';
 import { Command } from 'commander';
 import init from '../lib/index.js';
 
-const packageJson = fs.readJsonSync( path.join( import.meta.dirname, '..', 'package.json' ) );
+const packageJson = fs.readJsonSync( upath.join( import.meta.dirname, '..', 'package.json' ) );
 
 new Command( packageJson.name )
 	.argument( '[packageName]', 'name of the package (@scope/ckeditor5-*)' )
@@ -32,9 +32,9 @@ new Command( packageJson.name )
 
 function isInsideGitRepositoryCallback() {
 	// An absolute path to the repository that tracks the package.
-	const rootRepositoryPath = path.join( import.meta.dirname, '..', '..', '..' );
+	const rootRepositoryPath = upath.join( import.meta.dirname, '..', '..', '..' );
 
 	// The assumption here is that if the `--dev` flag was used, the entire repository is cloned.
 	// Otherwise, the executable was downloaded from npm, and it can't be executed in dev-mode.
-	return fs.existsSync( path.join( rootRepositoryPath, '.git' ) );
+	return fs.existsSync( upath.join( rootRepositoryPath, '.git' ) );
 }

--- a/packages/ckeditor5-package-generator/lib/utils/copy-files.js
+++ b/packages/ckeditor5-package-generator/lib/utils/copy-files.js
@@ -7,10 +7,10 @@ import chalk from 'chalk';
 import fs from 'fs';
 import { globSync } from 'glob';
 import mkdirp from 'mkdirp';
-import path from 'path';
+import upath from 'upath';
 import { template } from 'lodash-es';
 
-const TEMPLATE_PATH = path.join( import.meta.dirname, '..', 'templates' );
+const TEMPLATE_PATH = upath.join( import.meta.dirname, '..', 'templates' );
 
 /**
  * If the package name is not valid, prints the error and exits the process.
@@ -68,7 +68,7 @@ export default function copyFiles( logger, options ) {
  * @param {Object} data The data to fill in the template file.
  */
 function copyTemplate( templatePath, packagePath, data ) {
-	const rawFile = fs.readFileSync( path.join( TEMPLATE_PATH, templatePath ), 'utf-8' );
+	const rawFile = fs.readFileSync( upath.join( TEMPLATE_PATH, templatePath ), 'utf-8' );
 	const filledFile = template( rawFile )( data );
 
 	const processedTemplatePath = templatePath
@@ -79,9 +79,9 @@ function copyTemplate( templatePath, packagePath, data ) {
 		// Replace placeholder filenames with the class name.
 		.replace( /_PLACEHOLDER_/, data.formattedNames.plugin.lowerCaseMerged );
 
-	const destinationPath = path.join( packagePath, processedTemplatePath );
+	const destinationPath = upath.join( packagePath, processedTemplatePath );
 
 	// Make sure that the destination directory exists.
-	mkdirp.sync( path.dirname( destinationPath ) );
+	mkdirp.sync( upath.dirname( destinationPath ) );
 	fs.writeFileSync( destinationPath, filledFile );
 }

--- a/packages/ckeditor5-package-generator/lib/utils/create-directory.js
+++ b/packages/ckeditor5-package-generator/lib/utils/create-directory.js
@@ -6,7 +6,7 @@
 import chalk from 'chalk';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
-import path from 'path';
+import upath from 'upath';
 
 /**
  * Checks whether its possible to create a directory, and either creates it or ends the process with an error.
@@ -16,7 +16,7 @@ import path from 'path';
  */
 export default function createDirectory( logger, packageName ) {
 	const directoryName = packageName.split( '/' )[ 1 ];
-	const directoryPath = path.resolve( directoryName );
+	const directoryPath = upath.resolve( directoryName );
 
 	logger.process( `Checking whether the "${ chalk.cyan( directoryName ) }" directory can be created.` );
 

--- a/packages/ckeditor5-package-generator/lib/utils/get-dependencies-versions.js
+++ b/packages/ckeditor5-package-generator/lib/utils/get-dependencies-versions.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import path from 'path';
+import upath from 'upath';
 import getPackageVersion from './get-package-version.js';
 
 /**
@@ -72,6 +72,6 @@ function resolvePackageToolsDependency( logger, { dev, useReleaseDirectory } ) {
 
 	packageToolsPath.push( 'ckeditor5-package-tools' );
 
-	// Windows accepts unix-like paths in `package.json`, so let's unify it to avoid errors with paths.
-	return 'file:' + path.resolve( ...packageToolsPath ).split( path.sep ).join( path.posix.sep );
+	// Windows accepts unix-like paths in `package.json`.
+	return 'file:' + upath.resolve( ...packageToolsPath );
 }

--- a/packages/ckeditor5-package-generator/lib/utils/initialize-git-repository.js
+++ b/packages/ckeditor5-package-generator/lib/utils/initialize-git-repository.js
@@ -4,7 +4,7 @@
  */
 
 import fs from 'fs';
-import path from 'path';
+import upath from 'upath';
 import { execSync } from 'child_process';
 
 /**
@@ -28,6 +28,6 @@ export default function initializeGitRepository( directoryPath, logger ) {
 		// Remove the `.git` directory in case of an error. It may happen that the developer didn't configure Git yet.
 		// We could have resolved the error ourselves.
 		// See: https://github.com/ember-cli/ember-cli/blob/3192a441e13ec7e88c71d480778971d81bfa436c/lib/tasks/git-init.js#L49-L66.
-		fs.rmSync( path.join( directoryPath, '.git' ), { recursive: true, force: true } );
+		fs.rmSync( upath.join( directoryPath, '.git' ), { recursive: true, force: true } );
 	}
 }

--- a/packages/ckeditor5-package-generator/tests/utils/copy-files.js
+++ b/packages/ckeditor5-package-generator/tests/utils/copy-files.js
@@ -13,12 +13,6 @@ vi.mock( 'chalk', () => ( {
 		gray: vi.fn()
 	}
 } ) );
-vi.mock( 'path', () => ( {
-	default: {
-		dirname: () => '.',
-		join: ( ...chunks ) => chunks.join( '/' )
-	}
-} ) );
 vi.mock( 'fs' );
 vi.mock( 'glob' );
 vi.mock( 'mkdirp' );

--- a/packages/ckeditor5-package-generator/tests/utils/create-directory.js
+++ b/packages/ckeditor5-package-generator/tests/utils/create-directory.js
@@ -13,7 +13,7 @@ vi.mock( 'chalk', () => ( {
 		cyan: str => str
 	}
 } ) );
-vi.mock( 'path', () => ( {
+vi.mock( 'upath', () => ( {
 	default: {
 		resolve: ( ...chunks ) => [ 'resolved', ...chunks ].join( '/' )
 	}

--- a/packages/ckeditor5-package-generator/tests/utils/get-dependencies-versions.js
+++ b/packages/ckeditor5-package-generator/tests/utils/get-dependencies-versions.js
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import path from 'path';
+import upath from 'upath';
 import getPackageVersion from '../../lib/utils/get-package-version.js';
 import getDependenciesVersions from '../../lib/utils/get-dependencies-versions.js';
 
@@ -101,9 +101,8 @@ describe( 'lib/utils/get-dependencies-versions', () => {
 	it( 'returns an absolute path to the "@ckeditor/ckeditor5-package-tools" package if the "dev" option is enabled', () => {
 		const returnedValue = getDependenciesVersions( stubs.logger, { dev: true } );
 
-		const PROJECT_ROOT_DIRECTORY = path.join( import.meta.dirname, '..', '..', '..' );
-		let packageTools = 'file:' + path.resolve( PROJECT_ROOT_DIRECTORY, 'ckeditor5-package-tools' );
-		packageTools = packageTools.split( path.sep ).join( path.posix.sep );
+		const PROJECT_ROOT_DIRECTORY = upath.join( import.meta.dirname, '..', '..', '..' );
+		const packageTools = 'file:' + upath.resolve( PROJECT_ROOT_DIRECTORY, 'ckeditor5-package-tools' );
 
 		expect( returnedValue.packageTools ).toEqual( packageTools );
 	} );
@@ -112,9 +111,8 @@ describe( 'lib/utils/get-dependencies-versions', () => {
 	it( 'returns an absolute path to the `release/` directory for `@ckeditor/ckeditor5-package-tools` with `--use-release-directory` and `--dev', () => {
 		const returnedValue = getDependenciesVersions( stubs.logger, { dev: true, useReleaseDirectory: true } );
 
-		const PROJECT_ROOT_DIRECTORY = path.join( import.meta.dirname, '..', '..', '..', '..', 'release' );
-		let packageTools = 'file:' + path.resolve( PROJECT_ROOT_DIRECTORY, 'ckeditor5-package-tools' );
-		packageTools = packageTools.split( path.sep ).join( path.posix.sep );
+		const PROJECT_ROOT_DIRECTORY = upath.join( import.meta.dirname, '..', '..', '..', '..', 'release' );
+		const packageTools = 'file:' + upath.resolve( PROJECT_ROOT_DIRECTORY, 'ckeditor5-package-tools' );
 
 		expect( returnedValue.packageTools ).toEqual( packageTools );
 	} );

--- a/packages/ckeditor5-package-generator/tests/utils/initialize-git-repository.js
+++ b/packages/ckeditor5-package-generator/tests/utils/initialize-git-repository.js
@@ -8,11 +8,6 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 import initializeGitRepository from '../../lib/utils/initialize-git-repository.js';
 
-vi.mock( 'path', () => ( {
-	default: {
-		join: ( ...chunks ) => chunks.join( '/' )
-	}
-} ) );
 vi.mock( 'fs' );
 vi.mock( 'child_process' );
 

--- a/packages/ckeditor5-package-tools/lib/tasks/synchronize-translations.js
+++ b/packages/ckeditor5-package-tools/lib/tasks/synchronize-translations.js
@@ -3,14 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
-import path from 'path';
+import upath from 'upath';
 import { globSync } from 'glob';
 import { synchronizeTranslations } from '@ckeditor/ckeditor5-dev-translations';
 import { getCorePath } from '../utils/get-path.js';
 
 export default options => {
 	// Glob handles posix paths.
-	const sourceFilesGlob = path.join( options.cwd, 'src', '**', '*.[jt]s' ).split( /[\\/]/g ).join( '/' );
+	const sourceFilesGlob = upath.join( options.cwd, 'src', '**', '*.[jt]s' );
 
 	return synchronizeTranslations( {
 		// An array containing absolute paths the package sources.

--- a/packages/ckeditor5-package-tools/lib/utils/get-path.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-path.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import path from 'path';
+import upath from 'upath';
 import module from 'module';
 
 function getRequire() {
@@ -26,9 +26,9 @@ export function getThemePath( cwd ) {
  * @returns {string}
  */
 export function getCorePath() {
-	return path.relative(
+	return upath.relative(
 		process.cwd(),
-		path.dirname( getRequire().resolve( '@ckeditor/ckeditor5-core/package.json' ) )
+		upath.dirname( getRequire().resolve( '@ckeditor/ckeditor5-core/package.json' ) )
 	);
 }
 

--- a/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-dll.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-dll.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import path from 'path';
+import upath from 'upath';
 import fs from 'fs-extra';
 import webpack from 'webpack';
 import TerserPlugin from 'terser-webpack-plugin';
@@ -11,10 +11,10 @@ import { CKEditorTranslationsPlugin } from '@ckeditor/ckeditor5-dev-translations
 import { loaderDefinitions, getModuleResolutionPaths } from './webpack-utils.js';
 import { getMainManifestPath } from './get-path.js';
 
-const PACKAGE_ROOT_DIR = path.join( import.meta.dirname, '..', '..' );
+const PACKAGE_ROOT_DIR = upath.join( import.meta.dirname, '..', '..' );
 
 export default options => {
-	const pkgJson = fs.readJsonSync( path.join( options.cwd, 'package.json' ) );
+	const pkgJson = fs.readJsonSync( upath.join( options.cwd, 'package.json' ) );
 
 	// `dllName` is a short package name without the scope and the `ckeditor5-` prefix.
 	// E.g. for the package called `@ckeditor/ckeditor5-example-package`, the short name is `example-package`.
@@ -40,7 +40,7 @@ export default options => {
 
 	// If the package contains localization for the English language, which is the default option for the DLL build,
 	// include the CKEditor 5 Webpack plugin that produces translation files.
-	if ( fs.existsSync( path.join( options.cwd, 'lang', 'translations', 'en.po' ) ) ) {
+	if ( fs.existsSync( upath.join( options.cwd, 'lang', 'translations', 'en.po' ) ) ) {
 		webpackPlugins.push(
 			new CKEditorTranslationsPlugin( {
 				language: 'en',
@@ -51,7 +51,7 @@ export default options => {
 		);
 	}
 
-	const entryFileName = fs.readdirSync( path.join( options.cwd, 'src' ) )
+	const entryFileName = fs.readdirSync( upath.join( options.cwd, 'src' ) )
 		.find( filePath => /^index\.[jt]s$/.test( filePath ) );
 
 	const moduleResolutionPaths = getModuleResolutionPaths( PACKAGE_ROOT_DIR );
@@ -63,12 +63,12 @@ export default options => {
 			hints: false
 		},
 
-		entry: path.join( options.cwd, 'src', entryFileName ),
+		entry: upath.join( options.cwd, 'src', entryFileName ),
 
 		output: {
 			filename: dllName + '.js',
 			library: [ 'CKEditor5', dllWindowKey ],
-			path: path.join( options.cwd, 'build' ),
+			path: upath.join( options.cwd, 'build' ),
 			libraryTarget: 'window'
 		},
 

--- a/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-server.js
+++ b/packages/ckeditor5-package-tools/lib/utils/get-webpack-config-server.js
@@ -4,12 +4,12 @@
  */
 
 import fs from 'fs';
-import path from 'path';
+import upath from 'upath';
 import webpack from 'webpack';
 import { CKEditorTranslationsPlugin } from '@ckeditor/ckeditor5-dev-translations';
 import { loaderDefinitions, getModuleResolutionPaths } from './webpack-utils.js';
 
-const PACKAGE_ROOT_DIR = path.join( import.meta.dirname, '..', '..' );
+const PACKAGE_ROOT_DIR = upath.join( import.meta.dirname, '..', '..' );
 
 export default options => {
 	const webpackPlugins = [
@@ -31,7 +31,7 @@ export default options => {
 		);
 	}
 
-	const entryFileName = fs.readdirSync( path.join( options.cwd, 'sample' ) )
+	const entryFileName = fs.readdirSync( upath.join( options.cwd, 'sample' ) )
 		.find( filePath => /^ckeditor\.[jt]s$/.test( filePath ) );
 
 	const moduleResolutionPaths = getModuleResolutionPaths( PACKAGE_ROOT_DIR );
@@ -43,11 +43,11 @@ export default options => {
 			hints: false
 		},
 
-		entry: path.join( options.cwd, 'sample', entryFileName ),
+		entry: upath.join( options.cwd, 'sample', entryFileName ),
 
 		output: {
 			filename: 'ckeditor.dist.js',
-			path: path.join( options.cwd, 'sample' )
+			path: upath.join( options.cwd, 'sample' )
 		},
 
 		optimization: {
@@ -58,7 +58,7 @@ export default options => {
 
 		devServer: {
 			static: {
-				directory: path.join( options.cwd, 'sample' )
+				directory: upath.join( options.cwd, 'sample' )
 			},
 			compress: true
 		},

--- a/packages/ckeditor5-package-tools/lib/utils/update-entry-point.js
+++ b/packages/ckeditor5-package-tools/lib/utils/update-entry-point.js
@@ -3,11 +3,11 @@
  * For licensing, see LICENSE.md.
  */
 
-import path from 'path';
+import upath from 'upath';
 import { tools } from '@ckeditor/ckeditor5-dev-utils';
 
 export default ( options, lang ) => {
-	const pkgJsonPath = path.join( options.cwd, 'package.json' );
+	const pkgJsonPath = upath.join( options.cwd, 'package.json' );
 
 	tools.updateJSONFile( pkgJsonPath, json => {
 		json.main = json.main.replace( /(?<=\.)[tj]s$/, lang );

--- a/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/lib/utils/webpack-utils.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import path from 'path';
+import upath from 'upath';
 import { getThemePath } from './get-path.js';
 import { styles } from '@ckeditor/ckeditor5-dev-utils';
 
@@ -29,7 +29,7 @@ export const loaderDefinitions = {
 			test: /\.ts$/,
 			loader: 'ts-loader',
 			options: {
-				configFile: path.join( cwd, tsconfigName )
+				configFile: upath.join( cwd, tsconfigName )
 			}
 		};
 	},
@@ -67,7 +67,7 @@ export const loaderDefinitions = {
 export function getModuleResolutionPaths( packageRootDir ) {
 	return [
 		'node_modules',
-		path.resolve( packageRootDir, 'node_modules' )
+		upath.resolve( packageRootDir, 'node_modules' )
 	];
 }
 

--- a/packages/ckeditor5-package-tools/package.json
+++ b/packages/ckeditor5-package-tools/package.json
@@ -31,6 +31,7 @@
     "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "typescript": "5.0.4",
+    "upath": "^2.0.1",
     "webpack": "^5.94.0",
     "webpack-dev-server": "^5.0.4"
   },

--- a/packages/ckeditor5-package-tools/tests/tasks/synchronize-translations.js
+++ b/packages/ckeditor5-package-tools/tests/tasks/synchronize-translations.js
@@ -4,26 +4,14 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import path from 'path';
+import upath from 'upath';
 import { globSync } from 'glob';
 import * as devTranslations from '@ckeditor/ckeditor5-dev-translations';
 import synchronizeTranslations from '../../lib/tasks/synchronize-translations.js';
 
-vi.mock( 'path', async importOriginal => {
-	const mod = await importOriginal();
-
-	return {
-		...mod,
-		default: {
-			...mod.default,
-			join: ( ...chunks ) => chunks.join( '/' )
-		}
-	};
-} );
-
 vi.mock( 'module', () => ( {
 	default: {
-		createRequire: () => ( { resolve: () => path.resolve( process.cwd(), 'node_modules/@ckeditor/ckeditor5-core/package.json' ) } )
+		createRequire: () => ( { resolve: () => upath.resolve( process.cwd(), 'node_modules/@ckeditor/ckeditor5-core/package.json' ) } )
 	}
 } ) );
 
@@ -107,6 +95,7 @@ describe( 'lib/tasks/synchronize-translations', () => {
 
 	it( 'validates translation messages', () => {
 		synchronizeTranslations( {
+			cwd: '/workspace',
 			validateOnly: true
 		} );
 

--- a/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-dll.js
+++ b/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-dll.js
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import path from 'path';
+import upath from 'upath';
 import fs from 'fs-extra';
 import { CKEditorTranslationsPlugin } from '@ckeditor/ckeditor5-dev-translations';
 import { loaderDefinitions, getModuleResolutionPaths } from '../../lib/utils/webpack-utils.js';
@@ -17,15 +17,14 @@ const stubs = vi.hoisted( () => {
 	};
 } );
 
-vi.mock( 'path', async importOriginal => {
+vi.mock( 'upath', async importOriginal => {
 	const mod = await importOriginal();
 
 	return {
 		...mod,
 		default: {
-			...mod,
-			dirname: () => '/packages/ckeditor5-package-tools/lib/utils',
-			join: ( ...chunks ) => chunks.join( '/' )
+			...mod.default,
+			dirname: () => '/packages/ckeditor5-package-tools/lib/utils'
 		}
 	};
 } );
@@ -45,7 +44,7 @@ vi.mock( 'webpack', () => ( {
 } ) );
 vi.mock( 'module', () => ( {
 	default: {
-		createRequire: () => ( { resolve: () => path.resolve( process.cwd(), 'node_modules/@ckeditor/ckeditor5-core/package.json' ) } )
+		createRequire: () => ( { resolve: () => upath.resolve( process.cwd(), 'node_modules/@ckeditor/ckeditor5-core/package.json' ) } )
 	}
 } ) );
 vi.mock( 'fs-extra' );
@@ -149,7 +148,7 @@ describe( 'lib/utils/get-webpack-config-dll', () => {
 
 		const [ firstArgument ] = getModuleResolutionPaths.mock.calls[ 0 ];
 
-		expect( firstArgument.endsWith( '/packages/ckeditor5-package-tools/lib/utils/../..' ) ).toEqual( true );
+		expect( firstArgument.endsWith( '/packages/ckeditor5-package-tools' ) ).toEqual( true );
 	} );
 
 	it( 'processes the "index.js" file', () => {

--- a/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-server.js
+++ b/packages/ckeditor5-package-tools/tests/utils/get-webpack-config-server.js
@@ -16,12 +16,6 @@ const stubs = vi.hoisted( () => {
 	};
 } );
 
-vi.mock( 'path', () => ( {
-	default: {
-		dirname: () => '/packages/ckeditor5-package-tools/lib/utils',
-		join: ( ...chunks ) => chunks.join( '/' )
-	}
-} ) );
 vi.mock( 'webpack', () => ( {
 	default: {
 		DefinePlugin: class {
@@ -120,7 +114,7 @@ describe( 'lib/utils/get-webpack-config-server', () => {
 
 		const [ firstArgument ] = getModuleResolutionPaths.mock.calls[ 0 ];
 
-		expect( firstArgument.endsWith( '/packages/ckeditor5-package-tools/lib/utils/../..' ) ).toEqual( true );
+		expect( firstArgument.endsWith( '/packages/ckeditor5-package-tools' ) ).toEqual( true );
 	} );
 
 	it( 'processes the "ckeditor.js" file', () => {

--- a/packages/ckeditor5-package-tools/tests/utils/update-entry-point.js
+++ b/packages/ckeditor5-package-tools/tests/utils/update-entry-point.js
@@ -7,11 +7,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { tools } from '@ckeditor/ckeditor5-dev-utils';
 import updateEntryPoint from '../../lib/utils/update-entry-point.js';
 
-vi.mock( 'path', () => ( {
-	default: {
-		join: ( ...chunks ) => chunks.join( '/' ).replace( '/./', '/' )
-	}
-} ) );
 vi.mock( '@ckeditor/ckeditor5-dev-utils' );
 
 describe( 'lib/utils/update-entry-point', () => {

--- a/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
+++ b/packages/ckeditor5-package-tools/tests/utils/webpack-utils.js
@@ -4,12 +4,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import path from 'path';
+import upath from 'upath';
 import { styles } from '@ckeditor/ckeditor5-dev-utils';
 import { getThemePath } from '../../lib/utils/get-path.js';
 import * as webpackUtils from '../../lib/utils/webpack-utils.js';
 
-vi.mock( 'path', () => ( {
+vi.mock( 'upath', () => ( {
 	default: {
 		join: vi.fn( ( ...chunks ) => chunks.join( '/' ) ),
 		resolve: vi.fn( ( ...chunks ) => chunks.join( '/' ) )
@@ -203,8 +203,8 @@ describe( 'lib/utils/webpack-utils', () => {
 		it( 'loads "node_modules" from root of the "ckeditor5-package-tools" package', () => {
 			expect( moduleResolutionPaths[ 1 ] ).toEqual( 'root/directory/node_modules' );
 
-			expect( path.resolve ).toHaveBeenCalledTimes( 1 );
-			expect( path.resolve ).toHaveBeenCalledWith( 'root/directory', 'node_modules' );
+			expect( upath.resolve ).toHaveBeenCalledTimes( 1 );
+			expect( upath.resolve ).toHaveBeenCalledWith( 'root/directory', 'node_modules' );
 		} );
 	} );
 } );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       typescript:
         specifier: 5.0.4
         version: 5.0.4
+      upath:
+        specifier: ^2.0.1
+        version: 2.0.1
       webpack:
         specifier: ^5.94.0
         version: 5.101.3

--- a/scripts/ci/verify-build.js
+++ b/scripts/ci/verify-build.js
@@ -6,7 +6,7 @@
  */
 
 import fs from 'fs';
-import path from 'path';
+import upath from 'upath';
 import { spawn, spawnSync } from 'child_process';
 import { stripVTControlCharacters } from 'util';
 import chalk from 'chalk';
@@ -15,10 +15,10 @@ import { EXPECTED_PUBLISH_FILES, EXPECTED_LEGACY_PUBLISH_FILES, EXPECTED_SRC_DIR
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath( import.meta.url );
-const __dirname = path.dirname( __filename );
+const __dirname = upath.dirname( __filename );
 
-const REPOSITORY_DIRECTORY = path.join( __dirname, '..', '..' );
-const NEW_PACKAGE_DIRECTORY = path.join( REPOSITORY_DIRECTORY, '..', 'ckeditor5-test-package' );
+const REPOSITORY_DIRECTORY = upath.join( __dirname, '..', '..' );
+const NEW_PACKAGE_DIRECTORY = upath.join( REPOSITORY_DIRECTORY, '..', 'ckeditor5-test-package' );
 
 const VERIFICATION_TIMEOUT = 3 * 60 * 1000;
 
@@ -52,7 +52,7 @@ async function verifyBuild( { language, packageManager, customPluginName, instal
 
 	const supportsLegacyMethods = installationMethod !== 'current';
 
-	const projectRootName = path.basename( process.cwd() );
+	const projectRootName = upath.basename( process.cwd() );
 	const packageBuildCommand = [
 		'node',
 		`${ projectRootName }/packages/ckeditor5-package-generator/bin/index.js`,
@@ -96,7 +96,7 @@ async function verifyBuild( { language, packageManager, customPluginName, instal
 	logProcess( testSetupInfoMessage + '.' );
 
 	logProcess( 'Creating new package: "@ckeditor/ckeditor5-test-package"...' );
-	executeCommand( packageBuildCommand, { cwd: path.join( REPOSITORY_DIRECTORY, '..' ) } );
+	executeCommand( packageBuildCommand, { cwd: upath.join( REPOSITORY_DIRECTORY, '..' ) } );
 
 	logProcess( 'Executing tests...' );
 	executeCommand( [ 'npm', 'run', 'test' ], { cwd: NEW_PACKAGE_DIRECTORY } );
@@ -127,7 +127,7 @@ async function verifyBuild( { language, packageManager, customPluginName, instal
 	await Promise.all( listOfDevelopmentServers )
 		.then( optionsList => {
 			optionsList.forEach( options => {
-				executeCommand( [ 'node', path.join( 'scripts', 'ci', 'verify-sample.js' ), options.url ], { cwd: REPOSITORY_DIRECTORY } );
+				executeCommand( [ 'node', upath.join( 'scripts', 'ci', 'verify-sample.js' ), options.url ], { cwd: REPOSITORY_DIRECTORY } );
 			} );
 
 			return optionsList;
@@ -346,7 +346,7 @@ function checkFileList( output, expectedPublishFiles ) {
  */
 function verifyPublishCleanup( lang, expectedSrcDirFiles, supportsLegacyMethods ) {
 	// "package.json" check.
-	const pkgJsonPath = path.join( NEW_PACKAGE_DIRECTORY, 'package.json' );
+	const pkgJsonPath = upath.join( NEW_PACKAGE_DIRECTORY, 'package.json' );
 	const pkgJsonRaw = fs.readFileSync( pkgJsonPath, 'utf-8' );
 	const pkgJsonContent = JSON.parse( pkgJsonRaw );
 
@@ -360,7 +360,7 @@ function verifyPublishCleanup( lang, expectedSrcDirFiles, supportsLegacyMethods 
 	}
 
 	// "src" directory check.
-	const srcDirPath = path.join( NEW_PACKAGE_DIRECTORY, 'src' );
+	const srcDirPath = upath.join( NEW_PACKAGE_DIRECTORY, 'src' );
 	const excessFiles = fs.readdirSync( srcDirPath )
 		.filter( file => !expectedSrcDirFiles.includes( file ) );
 

--- a/scripts/ci/verify-build.js
+++ b/scripts/ci/verify-build.js
@@ -12,12 +12,8 @@ import { stripVTControlCharacters } from 'util';
 import chalk from 'chalk';
 import parseArguments from './utils/parsearguments.js';
 import { EXPECTED_PUBLISH_FILES, EXPECTED_LEGACY_PUBLISH_FILES, EXPECTED_SRC_DIR_FILES } from './utils/expectedFiles.js';
-import { fileURLToPath } from 'url';
 
-const __filename = fileURLToPath( import.meta.url );
-const __dirname = upath.dirname( __filename );
-
-const REPOSITORY_DIRECTORY = upath.join( __dirname, '..', '..' );
+const REPOSITORY_DIRECTORY = upath.join( import.meta.dirname, '..', '..' );
 const NEW_PACKAGE_DIRECTORY = upath.join( REPOSITORY_DIRECTORY, '..', 'ckeditor5-test-package' );
 
 const VERIFICATION_TIMEOUT = 3 * 60 * 1000;

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,12 +5,8 @@
 
 import upath from 'upath';
 import fs from 'fs-extra';
-import { fileURLToPath } from 'url';
 
-const __filename = fileURLToPath( import.meta.url );
-const __dirname = upath.dirname( __filename );
-
-const ROOT_DIRECTORY = upath.join( __dirname, '..' );
+const ROOT_DIRECTORY = upath.join( import.meta.dirname, '..' );
 
 ( async () => {
 	// When installing a repository as a dependency, the `.git` directory does not exist.

--- a/scripts/release/utils/constants.js
+++ b/scripts/release/utils/constants.js
@@ -4,11 +4,7 @@
  */
 
 import upath from 'upath';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath( import.meta.url );
-const __dirname = upath.dirname( __filename );
 
 export const PACKAGES_DIRECTORY = 'packages';
 export const RELEASE_DIRECTORY = 'release';
-export const PACKAGE_GENERATOR_ROOT = upath.join( __dirname, '..', '..', '..' );
+export const PACKAGE_GENERATOR_ROOT = upath.join( import.meta.dirname, '..', '..', '..' );


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Replaced `path` package with `upath` to ensure that all paths are normalized.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #254

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
