### PR TITLE
Update `trigger_release_process` CI job to disable the redundant workflows option.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,8 +247,15 @@ jobs:
               circleci-agent step halt
             fi
       - run:
+          name: Disable the redundant workflows option
+          command: pnpm ckeditor5-dev-ci-circle-disable-auto-cancel-builds --organization ckeditor --repository ckeditor5-package-generator
+      - run:
           name: Trigger the release pipeline
           command: pnpm ckeditor5-dev-ci-trigger-circle-build --slug ckeditor/ckeditor5-package-generator --release-branch epic/ci/4168-drop-oim
+      - run:
+          name: Enable the redundant workflows option
+          command: pnpm ckeditor5-dev-ci-circle-enable-auto-cancel-builds --organization ckeditor --repository ckeditor5-package-generator
+          when: always
 
   release_project:
     docker:


### PR DESCRIPTION
### 🚀 Summary

Update `trigger_release_process` CI job to disable the redundant workflows option.

---

### 📌 Related issues

N/A

---

### 💡 Additional information

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI workflow change that only toggles a CircleCI setting around a release trigger; main risk is leaving the setting disabled if the disable step fails before the `always` re-enable runs.
> 
> **Overview**
> Updates the CircleCI `trigger_release_process` job to temporarily **disable CircleCI “auto-cancel redundant workflows”** before triggering the downstream release pipeline, then re-enable it afterwards.
> 
> The re-enable step is guarded with `when: always` to ensure the setting is restored even if the trigger step fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fe31fc83fbe437a4e9e437afaa202ef97c44d49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->