### PR TITLE
Reduce resource class for the `notify_ci_failure` job to `small`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
   notify_ci_failure:
     docker:
       - image: cimg/node:24.11.0
+    resource_class: small
     parameters:
       hideAuthor:
         type: string


### PR DESCRIPTION
### 🚀 Summary

As in the title, nothing more to add.

---

### 📌 Related issues

* See: https://github.com/ckeditor/ckeditor5-internal/issues/4292.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI configuration change that only affects the resource size of a notification job; main risk is potential slowdown/timeouts if the job needs more compute.
> 
> **Overview**
> Reduces CircleCI compute allocation for the `notify_ci_failure` job by explicitly setting `resource_class: small` in `.circleci/config.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7643ae80914e59682ce4e5a8bb55debc47b2e1ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->