### PR TITLE
Bumped vite.

### DIFF
--- a/.changelog/20260701114900_fix_vite.md
+++ b/.changelog/20260701114900_fix_vite.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-package-generator
+---
+
+Generated packages now require Vite `^8.1.2`.

--- a/packages/ckeditor5-package-generator/lib/templates/js/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/js/package.json
@@ -48,7 +48,7 @@
     "stylelint": "^16.0.0",
     "stylelint-config-ckeditor5": "^<%= packageVersions.stylelintConfigCkeditor5 %>",
     "typescript": "5.5.4",
-    "vite": "^8.0.0",
+    "vite": "^8.1.2",
     "vite-plugin-svgo": "^2.0.0",
     "vitest": "^4.1.7",
     "webdriverio": "^9.19.2"

--- a/packages/ckeditor5-package-generator/lib/templates/ts/package.json
+++ b/packages/ckeditor5-package-generator/lib/templates/ts/package.json
@@ -50,7 +50,7 @@
     "stylelint": "^16.0.0",
     "stylelint-config-ckeditor5": "^<%= packageVersions.stylelintConfigCkeditor5 %>",
     "typescript": "5.5.4",
-    "vite": "^8.0.0",
+    "vite": "^8.1.2",
     "vite-plugin-svgo": "^2.0.0",
     "vitest": "^4.1.7",
     "webdriverio": "^9.19.2"


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Vite `8.1.1` caused the following error on CI:

`11:40:05 AM [vite] Internal server error: Failed to parse source for import analysis because the content contains invalid JS syntax. If you are using JSX, make sure to name the file with the .jsx or .tsx extension.`

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #000

---

### 💡 Additional information

https://app.circleci.com/pipelines/github/ckeditor/ckeditor5-package-generator/1640/workflows/d3940710-2dcf-4e14-923e-b5c6000326ec/jobs/14822
