### PR TITLE
Pin shared ESLint linter packages to the ESLint 9 compatible line

### DIFF
--- a/.changelog/20260720000000_fix_eslint9_linters.md
+++ b/.changelog/20260720000000_fix_eslint9_linters.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-package-generator
+---
+
+Generated packages now pin `eslint-config-ckeditor5` and `eslint-plugin-ckeditor5-rules` to the ESLint 9 compatible major line, so that installing their dependencies no longer fails on an ESLint peer dependency conflict.

--- a/packages/ckeditor5-package-generator/lib/utils/get-dependencies-versions.js
+++ b/packages/ckeditor5-package-generator/lib/utils/get-dependencies-versions.js
@@ -32,8 +32,8 @@ export default async function getDependenciesVersions() {
 		getPackageVersion( '@ckeditor/ckeditor5-inspector' ),
 		getPackageVersion( '@ckeditor/ckeditor5-dev-build-tools' ),
 		getPackageVersion( '@ckeditor/ckeditor5-dev-translations' ),
-		getPackageVersion( 'eslint-config-ckeditor5' ),
-		getPackageVersion( 'eslint-plugin-ckeditor5-rules' ),
+		getPackageVersion( 'eslint-config-ckeditor5', '^17.0.0' ),
+		getPackageVersion( 'eslint-plugin-ckeditor5-rules', '^17.0.0' ),
 		getPackageVersion( 'stylelint-config-ckeditor5' )
 	] );
 

--- a/packages/ckeditor5-package-generator/lib/utils/get-package-version.js
+++ b/packages/ckeditor5-package-generator/lib/utils/get-package-version.js
@@ -11,14 +11,25 @@ const execAsync = promisify( exec );
 /**
  * Returns version of the specified package.
  *
+ * When `versionRange` is provided, the highest version matching the given semver range is returned.
+ * This allows pinning a dependency to a specific (e.g. compatible) major line instead of always
+ * resolving to the latest published version.
+ *
  * @param {String} packageName Name of the package to check the version of.
+ * @param {String} [versionRange] Optional semver range used to narrow down the resolved version.
  * @return {Promise<String>}
  */
-export default async function getPackageVersion( packageName ) {
+export default async function getPackageVersion( packageName, versionRange = null ) {
+	const packageIdentifier = versionRange ? `${ packageName }@${ versionRange }` : packageName;
+
 	const { stdout } = await execAsync(
-		`npm view ${ packageName } version`,
+		`npm view ${ packageIdentifier } version --json`,
 		{ encoding: 'utf-8' }
 	);
 
-	return stdout.trim();
+	const versions = JSON.parse( stdout.trim() );
+
+	// A range matching multiple versions is returned by npm as an array sorted in ascending order,
+	// so the last item is the highest matching version. A single match is returned as a string.
+	return Array.isArray( versions ) ? versions.at( -1 ) : versions;
 }

--- a/packages/ckeditor5-package-generator/tests/utils/get-dependencies-versions.js
+++ b/packages/ckeditor5-package-generator/tests/utils/get-dependencies-versions.js
@@ -71,9 +71,19 @@ describe( 'lib/utils/get-dependencies-versions', () => {
 		expect( returnedValue.eslintConfigCkeditor5 ).toEqual( '5.0.0' );
 	} );
 
+	it( 'pins "eslint-config-ckeditor5" to the ESLint 9 compatible major line', async () => {
+		await getDependenciesVersions();
+		expect( getPackageVersion ).toHaveBeenCalledWith( 'eslint-config-ckeditor5', '^17.0.0' );
+	} );
+
 	it( 'returns an object with a version of the "eslint-plugin-ckeditor5-rules"', async () => {
 		const returnedValue = await getDependenciesVersions();
 		expect( returnedValue.eslintPluginCkeditor5Rules ).toEqual( '5.0.0' );
+	} );
+
+	it( 'pins "eslint-plugin-ckeditor5-rules" to the ESLint 9 compatible major line', async () => {
+		await getDependenciesVersions();
+		expect( getPackageVersion ).toHaveBeenCalledWith( 'eslint-plugin-ckeditor5-rules', '^17.0.0' );
 	} );
 
 	it( 'returns an object with a version of the "stylelint-config-ckeditor5" package', async () => {

--- a/packages/ckeditor5-package-generator/tests/utils/get-package-version.js
+++ b/packages/ckeditor5-package-generator/tests/utils/get-package-version.js
@@ -14,7 +14,7 @@ vi.mock( 'node:child_process', () => ( {
 describe( 'lib/utils/get-package-version', () => {
 	beforeEach( () => {
 		vi.mocked( childProcess.exec ).mockImplementation( ( command, options, callback ) => {
-			callback( null, { stdout: '30.0.0', stderr: '' } );
+			callback( null, { stdout: '"30.0.0"', stderr: '' } );
 		} );
 	} );
 
@@ -33,7 +33,7 @@ describe( 'lib/utils/get-package-version', () => {
 
 		expect( childProcess.exec ).toHaveBeenCalledTimes( 1 );
 		expect( childProcess.exec ).toHaveBeenCalledWith(
-			'npm view ckeditor5 version',
+			'npm view ckeditor5 version --json',
 			{ encoding: 'utf-8' },
 			expect.any( Function )
 		);
@@ -44,7 +44,7 @@ describe( 'lib/utils/get-package-version', () => {
 
 		expect( childProcess.exec ).toHaveBeenCalledTimes( 1 );
 		expect( childProcess.exec ).toHaveBeenCalledWith(
-			'npm view @ckeditor/ckeditor5-inspector version',
+			'npm view @ckeditor/ckeditor5-inspector version --json',
 			{ encoding: 'utf-8' },
 			expect.any( Function )
 		);
@@ -54,5 +54,26 @@ describe( 'lib/utils/get-package-version', () => {
 		const returnedValue = await getPackageVersion( 'ckeditor5' );
 
 		expect( returnedValue ).toEqual( '30.0.0' );
+	} );
+
+	it( 'narrows the resolved version down to the provided semver range', async () => {
+		await getPackageVersion( 'eslint-config-ckeditor5', '^17.0.0' );
+
+		expect( childProcess.exec ).toHaveBeenCalledTimes( 1 );
+		expect( childProcess.exec ).toHaveBeenCalledWith(
+			'npm view eslint-config-ckeditor5@^17.0.0 version --json',
+			{ encoding: 'utf-8' },
+			expect.any( Function )
+		);
+	} );
+
+	it( 'returns the highest version when the range matches multiple versions', async () => {
+		vi.mocked( childProcess.exec ).mockImplementation( ( command, options, callback ) => {
+			callback( null, { stdout: '[ "17.0.0", "17.1.0", "17.1.1" ]', stderr: '' } );
+		} );
+
+		const returnedValue = await getPackageVersion( 'eslint-config-ckeditor5', '^17.0.0' );
+
+		expect( returnedValue ).toEqual( '17.1.1' );
 	} );
 } );


### PR DESCRIPTION
## Summary

Fixes the failing `package_js_npm` CI job (and the `pnpm`/`ts` verify-build variants), which broke after the release of `eslint-config-ckeditor5@18.0.0`.

`eslint-config-ckeditor5@18` bumped its `eslint` peer dependency to `^10.0.0`. The generator resolves the shared linter packages to their latest published version, so generated packages ended up combining `eslint-config-ckeditor5@^18` (peer `eslint@^10`) with the template's `eslint@^9.27.0`, producing an `ERESOLVE` failure during `npm install` — which then cascaded into `vitest`/`vite`/`eslint`/`stylelint` "not found" errors and the dev-server timeout.

## Approach

This is **step 1** of the agreed plan: keep the generated packages on ESLint 9 for now and unblock the current CI, rather than migrating to ESLint 10 (which is a separate, breaking change). Instead of hardcoding versions in the templates, the version-resolution helper is used to pull the linter packages under an ESLint 9 compatible line:

- `getPackageVersion()` now accepts an optional semver range and resolves to the highest matching published version (via `npm view <pkg>@<range> version --json`).
- `eslint-config-ckeditor5` and `eslint-plugin-ckeditor5-rules` are pinned to `^17.0.0` (the last major line supporting `eslint@^9`).

The template `eslint` version (`^9.27.0`) is intentionally left untouched.

## Follow-up (later steps in the plan)

1. Release this fix to npm.
2. Revert this pin once the generated packages are migrated to ESLint 10 (a BC change requiring template adjustments).

## Testing

- Unit tests updated and passing (17/17 in the affected files).
- Verified the resolved versions are now `17.1.1` for both linter packages.
- Reproduced the exact `npm install` from the CI log with the new versions via `--dry-run`: resolves cleanly, `eslint 9.39.5` installs alongside `eslint-config-ckeditor5 17.1.1`, no `ERESOLVE`.
